### PR TITLE
Fix support release asset name to compatibility.json

### DIFF
--- a/.github/workflows/support-release-rollover.yml
+++ b/.github/workflows/support-release-rollover.yml
@@ -59,14 +59,16 @@ jobs:
 
           if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
             echo "Release $TAG already exists; skip create"
-            exit 0
+          else
+            gh release create "$TAG" \
+              --repo "$REPO" \
+              --target "${{ steps.latest.outputs.branch }}" \
+              --title "$TAG" \
+              --notes "Auto-published support release for OpenClaw ${VERSION}\n\ncompat: ${VERSION} @ ${SHA}\n\nSupport branch: ${{ steps.latest.outputs.branch }}"
           fi
 
-          gh release create "$TAG" \
-            --repo "$REPO" \
-            --target "${{ steps.latest.outputs.branch }}" \
-            --title "$TAG" \
-            --notes "Auto-published support release for OpenClaw ${VERSION}\n\ncompat: ${VERSION} @ ${SHA}\n\nSupport branch: ${{ steps.latest.outputs.branch }}"
+          # Ensure official support releases always include finalized compatibility metadata.
+          gh release upload "$TAG" compatibility.json --repo "$REPO" --clobber
 
       - name: Prune old support branches (keep latest N)
         run: |


### PR DESCRIPTION
## Summary
- keep support release creation idempotent without early exit
- always upload the repository's finalized `compatibility.json` to the support release
- use `--clobber` so reruns replace stale assets

## Why
`overlay-ci` publishes a candidate artifact named `compatibility-candidate.json`, but official support releases should expose finalized compatibility metadata as `compatibility.json`.

This change ensures support releases carry the correct asset name/content from the repo state.