### PR TITLE
Delete stale compatibility-candidate release asset

### DIFF
--- a/.github/workflows/support-release-rollover.yml
+++ b/.github/workflows/support-release-rollover.yml
@@ -70,6 +70,9 @@ jobs:
           # Ensure official support releases always include finalized compatibility metadata.
           gh release upload "$TAG" compatibility.json --repo "$REPO" --clobber
 
+          # Remove stale candidate asset if present from prior workflow versions.
+          gh release delete-asset "$TAG" compatibility-candidate.json --repo "$REPO" --yes 2>/dev/null || true
+
       - name: Prune old support branches (keep latest N)
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary\n- keep uploading finalized `compatibility.json` to support releases\n- delete legacy `compatibility-candidate.json` asset after upload if it exists\n\n## Why\nA prior workflow version uploaded `compatibility-candidate.json`. This cleanup keeps release assets canonical and avoids stale metadata lingering on support release tags.