### PR TITLE
fix(compat): rebase auto-compat patchset for v2026.2.22-2

### DIFF
--- a/compatibility.json
+++ b/compatibility.json
@@ -16,6 +16,20 @@
   },
   "supported": [
     {
+      "id": "oc-2026.2.22-2-45febecf2a2d",
+      "openclawVersion": "2026.2.22-2",
+      "commitSha": "45febecf2a2d91fd1a378bb2cae38ec21e71857e",
+      "upstreamBaseCommit": "45febecf2a2d91fd1a378bb2cae38ec21e71857e",
+      "overlayHeadCommit": "94f8faaf52d5fff1a21e7b4a4c2765f95e1fdbb7",
+      "patchSetDir": "patches/45febecf2a2d-autocompat",
+      "binaryArtifact": "dist-overlay.tar.gz",
+      "atlasCompat": {
+        "memory_search": "expected",
+        "memory_get": "expected"
+      },
+      "notes": "Auto-candidate generated from rebased overlay patchset for issue #18"
+    },
+    {
       "id": "oc-2026.2.21-2-35a57bc94083",
       "openclawVersion": "2026.2.21-2",
       "commitSha": "35a57bc940833a6c1f594b2308e349e5ee0148db",

--- a/patches/45febecf2a2d-autocompat/0001-feat-exec-guard-long-exec-in-main-sessions-via-polic.patch
+++ b/patches/45febecf2a2d-autocompat/0001-feat-exec-guard-long-exec-in-main-sessions-via-polic.patch
@@ -1,0 +1,1039 @@
+From 98e8b38a94c5fcad9420d8f97c467388c75ec2e8 Mon Sep 17 00:00:00 2001
+From: dddabtc <zhaodali78@gmail.com>
+Date: Thu, 19 Feb 2026 00:26:43 -0400
+Subject: [PATCH 01/16] feat(exec): guard long exec in main sessions via policy
+
+---
+ src/agents/bash-tools.exec-types.ts           |   7 +
+ ...ash-tools.exec.main-session-policy.test.ts |  38 +
+ src/agents/bash-tools.exec.ts                 |  40 +
+ src/agents/pi-tools-agent-config.test.ts      |  26 +
+ src/agents/pi-tools.ts                        |  14 +
+ src/config/schema.ts                          | 761 ++++++++++++++++++
+ src/config/types.openclaw.ts                  |   7 +
+ src/config/zod-schema.ts                      |  13 +
+ 8 files changed, 906 insertions(+)
+ create mode 100644 src/agents/bash-tools.exec.main-session-policy.test.ts
+
+diff --git a/src/agents/bash-tools.exec-types.ts b/src/agents/bash-tools.exec-types.ts
+index 24227a134..ad94fd67f 100644
+--- a/src/agents/bash-tools.exec-types.ts
++++ b/src/agents/bash-tools.exec-types.ts
+@@ -2,6 +2,12 @@ import type { ExecAsk, ExecHost, ExecSecurity } from "../infra/exec-approvals.js
+ import type { SafeBinProfileFixture } from "../infra/exec-safe-bin-policy.js";
+ import type { BashSandboxConfig } from "./bash-tools.shared.js";
+ 
++export type ExecMainSessionPolicy = {
++  forbidLongExec?: boolean;
++  requireBackgroundForExec?: boolean;
++  maxExecTimeoutSec?: number;
++};
++
+ export type ExecToolDefaults = {
+   host?: ExecHost;
+   security?: ExecSecurity;
+@@ -24,6 +30,7 @@ export type ExecToolDefaults = {
+   notifyOnExit?: boolean;
+   notifyOnExitEmptySuccess?: boolean;
+   cwd?: string;
++  mainSessionPolicy?: ExecMainSessionPolicy;
+ };
+ 
+ export type ExecElevatedDefaults = {
+diff --git a/src/agents/bash-tools.exec.main-session-policy.test.ts b/src/agents/bash-tools.exec.main-session-policy.test.ts
+new file mode 100644
+index 000000000..567311829
+--- /dev/null
++++ b/src/agents/bash-tools.exec.main-session-policy.test.ts
+@@ -0,0 +1,38 @@
++import { describe, expect, it } from "vitest";
++import { createExecTool } from "./bash-tools.exec.js";
++
++describe("exec main-session long-run guard", () => {
++  it("allows short foreground exec in main session", async () => {
++    const tool = createExecTool({
++      sessionKey: "agent:alpha:main",
++      mainSessionPolicy: {
++        forbidLongExec: true,
++        maxExecTimeoutSec: 120,
++      },
++    });
++
++    const result = await tool.execute("call-allow", {
++      command: "echo ok",
++      timeout: 30,
++      yieldMs: 1000,
++    });
++
++    expect(result.details.status).toBe("completed");
++  });
++
++  it("rejects long foreground exec in main session", async () => {
++    const tool = createExecTool({
++      sessionKey: "agent:alpha:main",
++      mainSessionPolicy: {
++        forbidLongExec: true,
++        maxExecTimeoutSec: 120,
++      },
++    });
++
++    await expect(
++      tool.execute("call-deny", {
++        command: "sleep 1",
++      }),
++    ).rejects.toThrow("Main session policy blocked exec");
++  });
++});
+diff --git a/src/agents/bash-tools.exec.ts b/src/agents/bash-tools.exec.ts
+index 7fd16e36e..06201a2e7 100644
+--- a/src/agents/bash-tools.exec.ts
++++ b/src/agents/bash-tools.exec.ts
+@@ -30,6 +30,7 @@ import {
+ } from "./bash-tools.exec-runtime.js";
+ import type {
+   ExecElevatedDefaults,
++  ExecMainSessionPolicy,
+   ExecToolDefaults,
+   ExecToolDetails,
+ } from "./bash-tools.exec-types.js";
+@@ -47,6 +48,7 @@ import { assertSandboxPath } from "./sandbox-paths.js";
+ export type { BashSandboxConfig } from "./bash-tools.shared.js";
+ export type {
+   ExecElevatedDefaults,
++  ExecMainSessionPolicy,
+   ExecToolDefaults,
+   ExecToolDetails,
+ } from "./bash-tools.exec-types.js";
+@@ -147,6 +149,20 @@ async function validateScriptFileForShellBleed(params: {
+   }
+ }
+ 
++
++function isMainAgentSession(sessionKey?: string) {
++  const parsed = parseAgentSessionKey(sessionKey);
++  return parsed?.rest === "main";
++}
++
++function resolveMainSessionMaxExecTimeoutSec(policy?: ExecMainSessionPolicy) {
++  const raw = policy?.maxExecTimeoutSec;
++  if (typeof raw !== "number" || !Number.isFinite(raw) || raw <= 0) {
++    return 120;
++  }
++  return Math.floor(raw);
++}
++
+ export function createExecTool(
+   defaults?: ExecToolDefaults,
+   // oxlint-disable-next-line typescript/no-explicit-any
+@@ -222,6 +238,30 @@ export function createExecTool(
+         throw new Error("Provide a command to start.");
+       }
+ 
++      const mainSessionPolicy = defaults?.mainSessionPolicy;
++      if (isMainAgentSession(defaults?.sessionKey) && mainSessionPolicy?.forbidLongExec) {
++        const maxExecTimeoutSec = resolveMainSessionMaxExecTimeoutSec(mainSessionPolicy);
++        const timeoutSec = typeof params.timeout === "number" ? params.timeout : undefined;
++        const backgroundRequestedByPolicy = params.background === true;
++        const yieldRequestedByPolicy = typeof params.yieldMs === "number";
++        const yieldExceedsLimit =
++          !yieldRequestedByPolicy || (params.yieldMs as number) > 120_000;
++        const timeoutMissingOrTooLarge =
++          timeoutSec === undefined || timeoutSec <= 0 || timeoutSec > maxExecTimeoutSec;
++        const longExecByTimeout = timeoutMissingOrTooLarge;
++        const longExecByForeground =
++          !backgroundRequestedByPolicy &&
++          (mainSessionPolicy.requireBackgroundForExec || yieldExceedsLimit);
++        if (longExecByTimeout || longExecByForeground) {
++          throw new Error(
++            [
++              `Main session policy blocked exec: this command is considered long-running (timeout must be <= ${maxExecTimeoutSec}s and long runs must use background mode).`,
++              "Use sessions_spawn for longer tasks, or rerun exec with background=true / an appropriate yieldMs and timeout.",
++            ].join("\n"),
++          );
++        }
++      }
++
+       const maxOutput = DEFAULT_MAX_OUTPUT;
+       const pendingMaxOutput = DEFAULT_PENDING_MAX_OUTPUT;
+       const warnings: string[] = [];
+diff --git a/src/agents/pi-tools-agent-config.test.ts b/src/agents/pi-tools-agent-config.test.ts
+index 96cac0501..a92171737 100644
+--- a/src/agents/pi-tools-agent-config.test.ts
++++ b/src/agents/pi-tools-agent-config.test.ts
+@@ -755,4 +755,30 @@ describe("Agent-specific tool filtering", () => {
+     const details = result?.details as { status?: string } | undefined;
+     expect(details?.status).toBe("completed");
+   });
++
++  it("threads sessionPolicies.main into exec long-run guard", async () => {
++    const cfg: OpenClawConfig = {
++      sessionPolicies: {
++        main: {
++          forbidLongExec: true,
++          maxExecTimeoutSec: 120,
++        },
++      },
++    };
++
++    const tools = createOpenClawCodingTools({
++      config: cfg,
++      sessionKey: "agent:main:main",
++      workspaceDir: "/tmp/test-main-policy",
++      agentDir: "/tmp/agent-main-policy",
++    });
++    const execTool = tools.find((tool) => tool.name === "exec");
++    expect(execTool).toBeDefined();
++
++    await expect(
++      execTool?.execute("call-main-policy", {
++        command: "echo done",
++      }),
++    ).rejects.toThrow("Main session policy blocked exec");
++  });
+ });
+diff --git a/src/agents/pi-tools.ts b/src/agents/pi-tools.ts
+index f40226c96..c6919e4b2 100644
+--- a/src/agents/pi-tools.ts
++++ b/src/agents/pi-tools.ts
+@@ -157,6 +157,19 @@ export function resolveToolLoopDetectionConfig(params: {
+       ...global.detectors,
+       ...agent.detectors,
+     },
++    host: globalExec?.host,
++    security: globalExec?.security,
++    ask: globalExec?.ask,
++    node: globalExec?.node,
++    pathPrepend: globalExec?.pathPrepend,
++    safeBins: globalExec?.safeBins,
++    backgroundMs: globalExec?.backgroundMs,
++    timeoutSec: globalExec?.timeoutSec,
++    approvalRunningNoticeMs: globalExec?.approvalRunningNoticeMs,
++    cleanupMs: globalExec?.cleanupMs,
++    notifyOnExit: globalExec?.notifyOnExit,
++    applyPatch: globalExec?.applyPatch,
++    mainSessionPolicy: cfg?.sessionPolicies?.main,
+   };
+ }
+ 
+@@ -387,6 +400,7 @@ export function createOpenClawCodingTools(options?: {
+     notifyOnExit: options?.exec?.notifyOnExit ?? execConfig.notifyOnExit,
+     notifyOnExitEmptySuccess:
+       options?.exec?.notifyOnExitEmptySuccess ?? execConfig.notifyOnExitEmptySuccess,
++    mainSessionPolicy: options?.exec?.mainSessionPolicy ?? execConfig.mainSessionPolicy,
+     sandbox: sandbox
+       ? {
+           containerName: sandbox.containerName,
+diff --git a/src/config/schema.ts b/src/config/schema.ts
+index d2add2c96..f30e4db02 100644
+--- a/src/config/schema.ts
++++ b/src/config/schema.ts
+@@ -11,6 +11,767 @@ export type ConfigSchema = ReturnType<typeof OpenClawSchema.toJSONSchema>;
+ 
+ type JsonSchemaNode = Record<string, unknown>;
+ 
++export type ConfigSchemaResponse = {
++  schema: ConfigSchema;
++  uiHints: ConfigUiHints;
++  version: string;
++  generatedAt: string;
++};
++
++export type PluginUiMetadata = {
++  id: string;
++  name?: string;
++  description?: string;
++  configUiHints?: Record<
++    string,
++    Pick<ConfigUiHint, "label" | "help" | "advanced" | "sensitive" | "placeholder">
++  >;
++  configSchema?: JsonSchemaNode;
++};
++
++export type ChannelUiMetadata = {
++  id: string;
++  label?: string;
++  description?: string;
++  configSchema?: JsonSchemaNode;
++  configUiHints?: Record<string, ConfigUiHint>;
++};
++
++const GROUP_LABELS: Record<string, string> = {
++  wizard: "Wizard",
++  update: "Update",
++  diagnostics: "Diagnostics",
++  logging: "Logging",
++  gateway: "Gateway",
++  nodeHost: "Node Host",
++  agents: "Agents",
++  tools: "Tools",
++  bindings: "Bindings",
++  audio: "Audio",
++  models: "Models",
++  messages: "Messages",
++  commands: "Commands",
++  session: "Session",
++  cron: "Cron",
++  hooks: "Hooks",
++  ui: "UI",
++  browser: "Browser",
++  talk: "Talk",
++  channels: "Messaging Channels",
++  skills: "Skills",
++  plugins: "Plugins",
++  discovery: "Discovery",
++  presence: "Presence",
++  voicewake: "Voice Wake",
++};
++
++const GROUP_ORDER: Record<string, number> = {
++  wizard: 20,
++  update: 25,
++  diagnostics: 27,
++  gateway: 30,
++  nodeHost: 35,
++  agents: 40,
++  tools: 50,
++  bindings: 55,
++  audio: 60,
++  models: 70,
++  messages: 80,
++  commands: 85,
++  session: 90,
++  cron: 100,
++  hooks: 110,
++  ui: 120,
++  browser: 130,
++  talk: 140,
++  channels: 150,
++  skills: 200,
++  plugins: 205,
++  discovery: 210,
++  presence: 220,
++  voicewake: 230,
++  logging: 900,
++};
++
++const FIELD_LABELS: Record<string, string> = {
++  "meta.lastTouchedVersion": "Config Last Touched Version",
++  "meta.lastTouchedAt": "Config Last Touched At",
++  "update.channel": "Update Channel",
++  "update.checkOnStart": "Update Check on Start",
++  "diagnostics.enabled": "Diagnostics Enabled",
++  "diagnostics.flags": "Diagnostics Flags",
++  "diagnostics.otel.enabled": "OpenTelemetry Enabled",
++  "diagnostics.otel.endpoint": "OpenTelemetry Endpoint",
++  "diagnostics.otel.protocol": "OpenTelemetry Protocol",
++  "diagnostics.otel.headers": "OpenTelemetry Headers",
++  "diagnostics.otel.serviceName": "OpenTelemetry Service Name",
++  "diagnostics.otel.traces": "OpenTelemetry Traces Enabled",
++  "diagnostics.otel.metrics": "OpenTelemetry Metrics Enabled",
++  "diagnostics.otel.logs": "OpenTelemetry Logs Enabled",
++  "diagnostics.otel.sampleRate": "OpenTelemetry Trace Sample Rate",
++  "diagnostics.otel.flushIntervalMs": "OpenTelemetry Flush Interval (ms)",
++  "diagnostics.cacheTrace.enabled": "Cache Trace Enabled",
++  "diagnostics.cacheTrace.filePath": "Cache Trace File Path",
++  "diagnostics.cacheTrace.includeMessages": "Cache Trace Include Messages",
++  "diagnostics.cacheTrace.includePrompt": "Cache Trace Include Prompt",
++  "diagnostics.cacheTrace.includeSystem": "Cache Trace Include System",
++  "agents.list.*.identity.avatar": "Identity Avatar",
++  "agents.list.*.skills": "Agent Skill Filter",
++  "gateway.remote.url": "Remote Gateway URL",
++  "gateway.remote.sshTarget": "Remote Gateway SSH Target",
++  "gateway.remote.sshIdentity": "Remote Gateway SSH Identity",
++  "gateway.remote.token": "Remote Gateway Token",
++  "gateway.remote.password": "Remote Gateway Password",
++  "gateway.remote.tlsFingerprint": "Remote Gateway TLS Fingerprint",
++  "gateway.auth.token": "Gateway Token",
++  "gateway.auth.password": "Gateway Password",
++  "tools.media.image.enabled": "Enable Image Understanding",
++  "tools.media.image.maxBytes": "Image Understanding Max Bytes",
++  "tools.media.image.maxChars": "Image Understanding Max Chars",
++  "tools.media.image.prompt": "Image Understanding Prompt",
++  "tools.media.image.timeoutSeconds": "Image Understanding Timeout (sec)",
++  "tools.media.image.attachments": "Image Understanding Attachment Policy",
++  "tools.media.image.models": "Image Understanding Models",
++  "tools.media.image.scope": "Image Understanding Scope",
++  "tools.media.models": "Media Understanding Shared Models",
++  "tools.media.concurrency": "Media Understanding Concurrency",
++  "tools.media.audio.enabled": "Enable Audio Understanding",
++  "tools.media.audio.maxBytes": "Audio Understanding Max Bytes",
++  "tools.media.audio.maxChars": "Audio Understanding Max Chars",
++  "tools.media.audio.prompt": "Audio Understanding Prompt",
++  "tools.media.audio.timeoutSeconds": "Audio Understanding Timeout (sec)",
++  "tools.media.audio.language": "Audio Understanding Language",
++  "tools.media.audio.attachments": "Audio Understanding Attachment Policy",
++  "tools.media.audio.models": "Audio Understanding Models",
++  "tools.media.audio.scope": "Audio Understanding Scope",
++  "tools.media.video.enabled": "Enable Video Understanding",
++  "tools.media.video.maxBytes": "Video Understanding Max Bytes",
++  "tools.media.video.maxChars": "Video Understanding Max Chars",
++  "tools.media.video.prompt": "Video Understanding Prompt",
++  "tools.media.video.timeoutSeconds": "Video Understanding Timeout (sec)",
++  "tools.media.video.attachments": "Video Understanding Attachment Policy",
++  "tools.media.video.models": "Video Understanding Models",
++  "tools.media.video.scope": "Video Understanding Scope",
++  "tools.links.enabled": "Enable Link Understanding",
++  "tools.links.maxLinks": "Link Understanding Max Links",
++  "tools.links.timeoutSeconds": "Link Understanding Timeout (sec)",
++  "tools.links.models": "Link Understanding Models",
++  "tools.links.scope": "Link Understanding Scope",
++  "tools.profile": "Tool Profile",
++  "tools.alsoAllow": "Tool Allowlist Additions",
++  "agents.list[].tools.profile": "Agent Tool Profile",
++  "agents.list[].tools.alsoAllow": "Agent Tool Allowlist Additions",
++  "tools.byProvider": "Tool Policy by Provider",
++  "agents.list[].tools.byProvider": "Agent Tool Policy by Provider",
++  "tools.exec.applyPatch.enabled": "Enable apply_patch",
++  "tools.exec.applyPatch.allowModels": "apply_patch Model Allowlist",
++  "tools.exec.notifyOnExit": "Exec Notify On Exit",
++  "tools.exec.approvalRunningNoticeMs": "Exec Approval Running Notice (ms)",
++  "tools.exec.host": "Exec Host",
++  "tools.exec.security": "Exec Security",
++  "tools.exec.ask": "Exec Ask",
++  "tools.exec.node": "Exec Node Binding",
++  "tools.exec.pathPrepend": "Exec PATH Prepend",
++  "tools.exec.safeBins": "Exec Safe Bins",
++  "tools.message.allowCrossContextSend": "Allow Cross-Context Messaging",
++  "tools.message.crossContext.allowWithinProvider": "Allow Cross-Context (Same Provider)",
++  "tools.message.crossContext.allowAcrossProviders": "Allow Cross-Context (Across Providers)",
++  "tools.message.crossContext.marker.enabled": "Cross-Context Marker",
++  "tools.message.crossContext.marker.prefix": "Cross-Context Marker Prefix",
++  "tools.message.crossContext.marker.suffix": "Cross-Context Marker Suffix",
++  "tools.message.broadcast.enabled": "Enable Message Broadcast",
++  "tools.web.search.enabled": "Enable Web Search Tool",
++  "tools.web.search.provider": "Web Search Provider",
++  "tools.web.search.apiKey": "Brave Search API Key",
++  "tools.web.search.maxResults": "Web Search Max Results",
++  "tools.web.search.timeoutSeconds": "Web Search Timeout (sec)",
++  "tools.web.search.cacheTtlMinutes": "Web Search Cache TTL (min)",
++  "tools.web.fetch.enabled": "Enable Web Fetch Tool",
++  "tools.web.fetch.maxChars": "Web Fetch Max Chars",
++  "tools.web.fetch.timeoutSeconds": "Web Fetch Timeout (sec)",
++  "tools.web.fetch.cacheTtlMinutes": "Web Fetch Cache TTL (min)",
++  "tools.web.fetch.maxRedirects": "Web Fetch Max Redirects",
++  "tools.web.fetch.userAgent": "Web Fetch User-Agent",
++  "gateway.controlUi.basePath": "Control UI Base Path",
++  "gateway.controlUi.root": "Control UI Assets Root",
++  "gateway.controlUi.allowedOrigins": "Control UI Allowed Origins",
++  "gateway.controlUi.allowInsecureAuth": "Allow Insecure Control UI Auth",
++  "gateway.controlUi.dangerouslyDisableDeviceAuth": "Dangerously Disable Control UI Device Auth",
++  "gateway.http.endpoints.chatCompletions.enabled": "OpenAI Chat Completions Endpoint",
++  "gateway.reload.mode": "Config Reload Mode",
++  "gateway.reload.debounceMs": "Config Reload Debounce (ms)",
++  "gateway.nodes.browser.mode": "Gateway Node Browser Mode",
++  "gateway.nodes.browser.node": "Gateway Node Browser Pin",
++  "gateway.nodes.allowCommands": "Gateway Node Allowlist (Extra Commands)",
++  "gateway.nodes.denyCommands": "Gateway Node Denylist",
++  "nodeHost.browserProxy.enabled": "Node Browser Proxy Enabled",
++  "nodeHost.browserProxy.allowProfiles": "Node Browser Proxy Allowed Profiles",
++  "skills.load.watch": "Watch Skills",
++  "skills.load.watchDebounceMs": "Skills Watch Debounce (ms)",
++  "agents.defaults.workspace": "Workspace",
++  "agents.defaults.repoRoot": "Repo Root",
++  "agents.defaults.bootstrapMaxChars": "Bootstrap Max Chars",
++  "agents.defaults.envelopeTimezone": "Envelope Timezone",
++  "agents.defaults.envelopeTimestamp": "Envelope Timestamp",
++  "agents.defaults.envelopeElapsed": "Envelope Elapsed",
++  "agents.defaults.memorySearch": "Memory Search",
++  "agents.defaults.memorySearch.enabled": "Enable Memory Search",
++  "agents.defaults.memorySearch.sources": "Memory Search Sources",
++  "agents.defaults.memorySearch.extraPaths": "Extra Memory Paths",
++  "agents.defaults.memorySearch.experimental.sessionMemory":
++    "Memory Search Session Index (Experimental)",
++  "agents.defaults.memorySearch.provider": "Memory Search Provider",
++  "agents.defaults.memorySearch.remote.baseUrl": "Remote Embedding Base URL",
++  "agents.defaults.memorySearch.remote.apiKey": "Remote Embedding API Key",
++  "agents.defaults.memorySearch.remote.headers": "Remote Embedding Headers",
++  "agents.defaults.memorySearch.remote.batch.concurrency": "Remote Batch Concurrency",
++  "agents.defaults.memorySearch.model": "Memory Search Model",
++  "agents.defaults.memorySearch.fallback": "Memory Search Fallback",
++  "agents.defaults.memorySearch.local.modelPath": "Local Embedding Model Path",
++  "agents.defaults.memorySearch.store.path": "Memory Search Index Path",
++  "agents.defaults.memorySearch.store.vector.enabled": "Memory Search Vector Index",
++  "agents.defaults.memorySearch.store.vector.extensionPath": "Memory Search Vector Extension Path",
++  "agents.defaults.memorySearch.chunking.tokens": "Memory Chunk Tokens",
++  "agents.defaults.memorySearch.chunking.overlap": "Memory Chunk Overlap Tokens",
++  "agents.defaults.memorySearch.sync.onSessionStart": "Index on Session Start",
++  "agents.defaults.memorySearch.sync.onSearch": "Index on Search (Lazy)",
++  "agents.defaults.memorySearch.sync.watch": "Watch Memory Files",
++  "agents.defaults.memorySearch.sync.watchDebounceMs": "Memory Watch Debounce (ms)",
++  "agents.defaults.memorySearch.sync.sessions.deltaBytes": "Session Delta Bytes",
++  "agents.defaults.memorySearch.sync.sessions.deltaMessages": "Session Delta Messages",
++  "agents.defaults.memorySearch.query.maxResults": "Memory Search Max Results",
++  "agents.defaults.memorySearch.query.minScore": "Memory Search Min Score",
++  "agents.defaults.memorySearch.query.hybrid.enabled": "Memory Search Hybrid",
++  "agents.defaults.memorySearch.query.hybrid.vectorWeight": "Memory Search Vector Weight",
++  "agents.defaults.memorySearch.query.hybrid.textWeight": "Memory Search Text Weight",
++  "agents.defaults.memorySearch.query.hybrid.candidateMultiplier":
++    "Memory Search Hybrid Candidate Multiplier",
++  "agents.defaults.memorySearch.cache.enabled": "Memory Search Embedding Cache",
++  "agents.defaults.memorySearch.cache.maxEntries": "Memory Search Embedding Cache Max Entries",
++  memory: "Memory",
++  "memory.backend": "Memory Backend",
++  "memory.citations": "Memory Citations Mode",
++  "memory.qmd.command": "QMD Binary",
++  "memory.qmd.includeDefaultMemory": "QMD Include Default Memory",
++  "memory.qmd.paths": "QMD Extra Paths",
++  "memory.qmd.paths.path": "QMD Path",
++  "memory.qmd.paths.pattern": "QMD Path Pattern",
++  "memory.qmd.paths.name": "QMD Path Name",
++  "memory.qmd.sessions.enabled": "QMD Session Indexing",
++  "memory.qmd.sessions.exportDir": "QMD Session Export Directory",
++  "memory.qmd.sessions.retentionDays": "QMD Session Retention (days)",
++  "memory.qmd.update.interval": "QMD Update Interval",
++  "memory.qmd.update.debounceMs": "QMD Update Debounce (ms)",
++  "memory.qmd.update.onBoot": "QMD Update on Startup",
++  "memory.qmd.update.embedInterval": "QMD Embed Interval",
++  "memory.qmd.limits.maxResults": "QMD Max Results",
++  "memory.qmd.limits.maxSnippetChars": "QMD Max Snippet Chars",
++  "memory.qmd.limits.maxInjectedChars": "QMD Max Injected Chars",
++  "memory.qmd.limits.timeoutMs": "QMD Search Timeout (ms)",
++  "memory.qmd.scope": "QMD Surface Scope",
++  "auth.profiles": "Auth Profiles",
++  "auth.order": "Auth Profile Order",
++  "auth.cooldowns.billingBackoffHours": "Billing Backoff (hours)",
++  "auth.cooldowns.billingBackoffHoursByProvider": "Billing Backoff Overrides",
++  "auth.cooldowns.billingMaxHours": "Billing Backoff Cap (hours)",
++  "auth.cooldowns.failureWindowHours": "Failover Window (hours)",
++  "agents.defaults.models": "Models",
++  "agents.defaults.model.primary": "Primary Model",
++  "agents.defaults.model.fallbacks": "Model Fallbacks",
++  "agents.defaults.imageModel.primary": "Image Model",
++  "agents.defaults.imageModel.fallbacks": "Image Model Fallbacks",
++  "agents.defaults.humanDelay.mode": "Human Delay Mode",
++  "agents.defaults.humanDelay.minMs": "Human Delay Min (ms)",
++  "agents.defaults.humanDelay.maxMs": "Human Delay Max (ms)",
++  "agents.defaults.cliBackends": "CLI Backends",
++  "commands.native": "Native Commands",
++  "commands.nativeSkills": "Native Skill Commands",
++  "commands.text": "Text Commands",
++  "commands.bash": "Allow Bash Chat Command",
++  "commands.bashForegroundMs": "Bash Foreground Window (ms)",
++  "commands.config": "Allow /config",
++  "commands.debug": "Allow /debug",
++  "commands.restart": "Allow Restart",
++  "commands.useAccessGroups": "Use Access Groups",
++  "commands.ownerAllowFrom": "Command Owners",
++  "ui.seamColor": "Accent Color",
++  "ui.assistant.name": "Assistant Name",
++  "ui.assistant.avatar": "Assistant Avatar",
++  "browser.evaluateEnabled": "Browser Evaluate Enabled",
++  "browser.snapshotDefaults": "Browser Snapshot Defaults",
++  "browser.snapshotDefaults.mode": "Browser Snapshot Mode",
++  "browser.remoteCdpTimeoutMs": "Remote CDP Timeout (ms)",
++  "browser.remoteCdpHandshakeTimeoutMs": "Remote CDP Handshake Timeout (ms)",
++  "session.dmScope": "DM Session Scope",
++  "session.agentToAgent.maxPingPongTurns": "Agent-to-Agent Ping-Pong Turns",
++  "sessionPolicies.main.forbidLongExec": "Main Session Exec Long-Run Guard",
++  "sessionPolicies.main.requireBackgroundForExec": "Main Session Exec Requires Background",
++  "sessionPolicies.main.maxExecTimeoutSec": "Main Session Exec Max Timeout (sec)",
++  "messages.ackReaction": "Ack Reaction Emoji",
++  "messages.ackReactionScope": "Ack Reaction Scope",
++  "messages.inbound.debounceMs": "Inbound Message Debounce (ms)",
++  "talk.apiKey": "Talk API Key",
++  "channels.whatsapp": "WhatsApp",
++  "channels.telegram": "Telegram",
++  "channels.telegram.customCommands": "Telegram Custom Commands",
++  "channels.discord": "Discord",
++  "channels.slack": "Slack",
++  "channels.mattermost": "Mattermost",
++  "channels.signal": "Signal",
++  "channels.imessage": "iMessage",
++  "channels.bluebubbles": "BlueBubbles",
++  "channels.msteams": "MS Teams",
++  "channels.telegram.botToken": "Telegram Bot Token",
++  "channels.telegram.dmPolicy": "Telegram DM Policy",
++  "channels.telegram.streamMode": "Telegram Draft Stream Mode",
++  "channels.telegram.draftChunk.minChars": "Telegram Draft Chunk Min Chars",
++  "channels.telegram.draftChunk.maxChars": "Telegram Draft Chunk Max Chars",
++  "channels.telegram.draftChunk.breakPreference": "Telegram Draft Chunk Break Preference",
++  "channels.telegram.retry.attempts": "Telegram Retry Attempts",
++  "channels.telegram.retry.minDelayMs": "Telegram Retry Min Delay (ms)",
++  "channels.telegram.retry.maxDelayMs": "Telegram Retry Max Delay (ms)",
++  "channels.telegram.retry.jitter": "Telegram Retry Jitter",
++  "channels.telegram.network.autoSelectFamily": "Telegram autoSelectFamily",
++  "channels.telegram.timeoutSeconds": "Telegram API Timeout (seconds)",
++  "channels.telegram.capabilities.inlineButtons": "Telegram Inline Buttons",
++  "channels.whatsapp.dmPolicy": "WhatsApp DM Policy",
++  "channels.whatsapp.selfChatMode": "WhatsApp Self-Phone Mode",
++  "channels.whatsapp.debounceMs": "WhatsApp Message Debounce (ms)",
++  "channels.signal.dmPolicy": "Signal DM Policy",
++  "channels.imessage.dmPolicy": "iMessage DM Policy",
++  "channels.bluebubbles.dmPolicy": "BlueBubbles DM Policy",
++  "channels.discord.dm.policy": "Discord DM Policy",
++  "channels.discord.retry.attempts": "Discord Retry Attempts",
++  "channels.discord.retry.minDelayMs": "Discord Retry Min Delay (ms)",
++  "channels.discord.retry.maxDelayMs": "Discord Retry Max Delay (ms)",
++  "channels.discord.retry.jitter": "Discord Retry Jitter",
++  "channels.discord.maxLinesPerMessage": "Discord Max Lines Per Message",
++  "channels.discord.intents.presence": "Discord Presence Intent",
++  "channels.discord.intents.guildMembers": "Discord Guild Members Intent",
++  "channels.discord.pluralkit.enabled": "Discord PluralKit Enabled",
++  "channels.discord.pluralkit.token": "Discord PluralKit Token",
++  "channels.slack.dm.policy": "Slack DM Policy",
++  "channels.slack.allowBots": "Slack Allow Bot Messages",
++  "channels.discord.token": "Discord Bot Token",
++  "channels.slack.botToken": "Slack Bot Token",
++  "channels.slack.appToken": "Slack App Token",
++  "channels.slack.userToken": "Slack User Token",
++  "channels.slack.userTokenReadOnly": "Slack User Token Read Only",
++  "channels.slack.thread.historyScope": "Slack Thread History Scope",
++  "channels.slack.thread.inheritParent": "Slack Thread Parent Inheritance",
++  "channels.mattermost.botToken": "Mattermost Bot Token",
++  "channels.mattermost.baseUrl": "Mattermost Base URL",
++  "channels.mattermost.chatmode": "Mattermost Chat Mode",
++  "channels.mattermost.oncharPrefixes": "Mattermost Onchar Prefixes",
++  "channels.mattermost.requireMention": "Mattermost Require Mention",
++  "channels.signal.account": "Signal Account",
++  "channels.imessage.cliPath": "iMessage CLI Path",
++  "agents.list[].skills": "Agent Skill Filter",
++  "agents.list[].identity.avatar": "Agent Avatar",
++  "discovery.mdns.mode": "mDNS Discovery Mode",
++  "plugins.enabled": "Enable Plugins",
++  "plugins.allow": "Plugin Allowlist",
++  "plugins.deny": "Plugin Denylist",
++  "plugins.load.paths": "Plugin Load Paths",
++  "plugins.slots": "Plugin Slots",
++  "plugins.slots.memory": "Memory Plugin",
++  "plugins.entries": "Plugin Entries",
++  "plugins.entries.*.enabled": "Plugin Enabled",
++  "plugins.entries.*.config": "Plugin Config",
++  "plugins.installs": "Plugin Install Records",
++  "plugins.installs.*.source": "Plugin Install Source",
++  "plugins.installs.*.spec": "Plugin Install Spec",
++  "plugins.installs.*.sourcePath": "Plugin Install Source Path",
++  "plugins.installs.*.installPath": "Plugin Install Path",
++  "plugins.installs.*.version": "Plugin Install Version",
++  "plugins.installs.*.installedAt": "Plugin Install Time",
++};
++
++const FIELD_HELP: Record<string, string> = {
++  "meta.lastTouchedVersion": "Auto-set when OpenClaw writes the config.",
++  "meta.lastTouchedAt": "ISO timestamp of the last config write (auto-set).",
++  "update.channel": 'Update channel for git + npm installs ("stable", "beta", or "dev").',
++  "update.checkOnStart": "Check for npm updates when the gateway starts (default: true).",
++  "gateway.remote.url": "Remote Gateway WebSocket URL (ws:// or wss://).",
++  "gateway.remote.tlsFingerprint":
++    "Expected sha256 TLS fingerprint for the remote gateway (pin to avoid MITM).",
++  "gateway.remote.sshTarget":
++    "Remote gateway over SSH (tunnels the gateway port to localhost). Format: user@host or user@host:port.",
++  "gateway.remote.sshIdentity": "Optional SSH identity file path (passed to ssh -i).",
++  "agents.list.*.skills":
++    "Optional allowlist of skills for this agent (omit = all skills; empty = no skills).",
++  "agents.list[].skills":
++    "Optional allowlist of skills for this agent (omit = all skills; empty = no skills).",
++  "agents.list[].identity.avatar":
++    "Avatar image path (relative to the agent workspace only) or a remote URL/data URL.",
++  "discovery.mdns.mode":
++    'mDNS broadcast mode ("minimal" default, "full" includes cliPath/sshPort, "off" disables mDNS).',
++  "gateway.auth.token":
++    "Required by default for gateway access (unless using Tailscale Serve identity); required for non-loopback binds.",
++  "gateway.auth.password": "Required for Tailscale funnel.",
++  "gateway.controlUi.basePath":
++    "Optional URL prefix where the Control UI is served (e.g. /openclaw).",
++  "gateway.controlUi.root":
++    "Optional filesystem root for Control UI assets (defaults to dist/control-ui).",
++  "gateway.controlUi.allowedOrigins":
++    "Allowed browser origins for Control UI/WebChat websocket connections (full origins only, e.g. https://control.example.com).",
++  "gateway.controlUi.allowInsecureAuth":
++    "Allow Control UI auth over insecure HTTP (token-only; not recommended).",
++  "gateway.controlUi.dangerouslyDisableDeviceAuth":
++    "DANGEROUS. Disable Control UI device identity checks (token/password only).",
++  "gateway.http.endpoints.chatCompletions.enabled":
++    "Enable the OpenAI-compatible `POST /v1/chat/completions` endpoint (default: false).",
++  "gateway.reload.mode": 'Hot reload strategy for config changes ("hybrid" recommended).',
++  "gateway.reload.debounceMs": "Debounce window (ms) before applying config changes.",
++  "gateway.nodes.browser.mode":
++    'Node browser routing ("auto" = pick single connected browser node, "manual" = require node param, "off" = disable).',
++  "gateway.nodes.browser.node": "Pin browser routing to a specific node id or name (optional).",
++  "gateway.nodes.allowCommands":
++    "Extra node.invoke commands to allow beyond the gateway defaults (array of command strings).",
++  "gateway.nodes.denyCommands":
++    "Commands to block even if present in node claims or default allowlist.",
++  "nodeHost.browserProxy.enabled": "Expose the local browser control server via node proxy.",
++  "nodeHost.browserProxy.allowProfiles":
++    "Optional allowlist of browser profile names exposed via the node proxy.",
++  "diagnostics.flags":
++    'Enable targeted diagnostics logs by flag (e.g. ["telegram.http"]). Supports wildcards like "telegram.*" or "*".',
++  "diagnostics.cacheTrace.enabled":
++    "Log cache trace snapshots for embedded agent runs (default: false).",
++  "diagnostics.cacheTrace.filePath":
++    "JSONL output path for cache trace logs (default: $OPENCLAW_STATE_DIR/logs/cache-trace.jsonl).",
++  "diagnostics.cacheTrace.includeMessages":
++    "Include full message payloads in trace output (default: true).",
++  "diagnostics.cacheTrace.includePrompt": "Include prompt text in trace output (default: true).",
++  "diagnostics.cacheTrace.includeSystem": "Include system prompt in trace output (default: true).",
++  "tools.exec.applyPatch.enabled":
++    "Experimental. Enables apply_patch for OpenAI models when allowed by tool policy.",
++  "tools.exec.applyPatch.allowModels":
++    'Optional allowlist of model ids (e.g. "gpt-5.2" or "openai/gpt-5.2").',
++  "tools.exec.notifyOnExit":
++    "When true (default), backgrounded exec sessions enqueue a system event and request a heartbeat on exit.",
++  "tools.exec.pathPrepend": "Directories to prepend to PATH for exec runs (gateway/sandbox).",
++  "tools.exec.safeBins":
++    "Allow stdin-only safe binaries to run without explicit allowlist entries.",
++  "tools.message.allowCrossContextSend":
++    "Legacy override: allow cross-context sends across all providers.",
++  "tools.message.crossContext.allowWithinProvider":
++    "Allow sends to other channels within the same provider (default: true).",
++  "tools.message.crossContext.allowAcrossProviders":
++    "Allow sends across different providers (default: false).",
++  "tools.message.crossContext.marker.enabled":
++    "Add a visible origin marker when sending cross-context (default: true).",
++  "tools.message.crossContext.marker.prefix":
++    'Text prefix for cross-context markers (supports "{channel}").',
++  "tools.message.crossContext.marker.suffix":
++    'Text suffix for cross-context markers (supports "{channel}").',
++  "tools.message.broadcast.enabled": "Enable broadcast action (default: true).",
++  "tools.web.search.enabled": "Enable the web_search tool (requires a provider API key).",
++  "tools.web.search.provider": 'Search provider ("brave" or "perplexity").',
++  "tools.web.search.apiKey": "Brave Search API key (fallback: BRAVE_API_KEY env var).",
++  "tools.web.search.maxResults": "Default number of results to return (1-10).",
++  "tools.web.search.timeoutSeconds": "Timeout in seconds for web_search requests.",
++  "tools.web.search.cacheTtlMinutes": "Cache TTL in minutes for web_search results.",
++  "tools.web.search.perplexity.apiKey":
++    "Perplexity or OpenRouter API key (fallback: PERPLEXITY_API_KEY or OPENROUTER_API_KEY env var).",
++  "tools.web.search.perplexity.baseUrl":
++    "Perplexity base URL override (default: https://openrouter.ai/api/v1 or https://api.perplexity.ai).",
++  "tools.web.search.perplexity.model":
++    'Perplexity model override (default: "perplexity/sonar-pro").',
++  "tools.web.fetch.enabled": "Enable the web_fetch tool (lightweight HTTP fetch).",
++  "tools.web.fetch.maxChars": "Max characters returned by web_fetch (truncated).",
++  "tools.web.fetch.maxCharsCap":
++    "Hard cap for web_fetch maxChars (applies to config and tool calls).",
++  "tools.web.fetch.timeoutSeconds": "Timeout in seconds for web_fetch requests.",
++  "tools.web.fetch.cacheTtlMinutes": "Cache TTL in minutes for web_fetch results.",
++  "tools.web.fetch.maxRedirects": "Maximum redirects allowed for web_fetch (default: 3).",
++  "tools.web.fetch.userAgent": "Override User-Agent header for web_fetch requests.",
++  "tools.web.fetch.readability":
++    "Use Readability to extract main content from HTML (fallbacks to basic HTML cleanup).",
++  "tools.web.fetch.firecrawl.enabled": "Enable Firecrawl fallback for web_fetch (if configured).",
++  "tools.web.fetch.firecrawl.apiKey": "Firecrawl API key (fallback: FIRECRAWL_API_KEY env var).",
++  "tools.web.fetch.firecrawl.baseUrl":
++    "Firecrawl base URL (e.g. https://api.firecrawl.dev or custom endpoint).",
++  "tools.web.fetch.firecrawl.onlyMainContent":
++    "When true, Firecrawl returns only the main content (default: true).",
++  "tools.web.fetch.firecrawl.maxAgeMs":
++    "Firecrawl maxAge (ms) for cached results when supported by the API.",
++  "tools.web.fetch.firecrawl.timeoutSeconds": "Timeout in seconds for Firecrawl requests.",
++  "channels.slack.allowBots":
++    "Allow bot-authored messages to trigger Slack replies (default: false).",
++  "channels.slack.thread.historyScope":
++    'Scope for Slack thread history context ("thread" isolates per thread; "channel" reuses channel history).',
++  "channels.slack.thread.inheritParent":
++    "If true, Slack thread sessions inherit the parent channel transcript (default: false).",
++  "channels.mattermost.botToken":
++    "Bot token from Mattermost System Console -> Integrations -> Bot Accounts.",
++  "channels.mattermost.baseUrl":
++    "Base URL for your Mattermost server (e.g., https://chat.example.com).",
++  "channels.mattermost.chatmode":
++    'Reply to channel messages on mention ("oncall"), on trigger chars (">" or "!") ("onchar"), or on every message ("onmessage").',
++  "channels.mattermost.oncharPrefixes": 'Trigger prefixes for onchar mode (default: [">", "!"]).',
++  "channels.mattermost.requireMention":
++    "Require @mention in channels before responding (default: true).",
++  "auth.profiles": "Named auth profiles (provider + mode + optional email).",
++  "auth.order": "Ordered auth profile IDs per provider (used for automatic failover).",
++  "auth.cooldowns.billingBackoffHours":
++    "Base backoff (hours) when a profile fails due to billing/insufficient credits (default: 5).",
++  "auth.cooldowns.billingBackoffHoursByProvider":
++    "Optional per-provider overrides for billing backoff (hours).",
++  "auth.cooldowns.billingMaxHours": "Cap (hours) for billing backoff (default: 24).",
++  "auth.cooldowns.failureWindowHours": "Failure window (hours) for backoff counters (default: 24).",
++  "agents.defaults.bootstrapMaxChars":
++    "Max characters of each workspace bootstrap file injected into the system prompt before truncation (default: 20000).",
++  "agents.defaults.repoRoot":
++    "Optional repository root shown in the system prompt runtime line (overrides auto-detect).",
++  "agents.defaults.envelopeTimezone":
++    'Timezone for message envelopes ("utc", "local", "user", or an IANA timezone string).',
++  "agents.defaults.envelopeTimestamp":
++    'Include absolute timestamps in message envelopes ("on" or "off").',
++  "agents.defaults.envelopeElapsed": 'Include elapsed time in message envelopes ("on" or "off").',
++  "agents.defaults.models": "Configured model catalog (keys are full provider/model IDs).",
++  "agents.defaults.memorySearch":
++    "Vector search over MEMORY.md and memory/*.md (per-agent overrides supported).",
++  "agents.defaults.memorySearch.sources":
++    'Sources to index for memory search (default: ["memory"]; add "sessions" to include session transcripts).',
++  "agents.defaults.memorySearch.extraPaths":
++    "Extra paths to include in memory search (directories or .md files; relative paths resolved from workspace).",
++  "agents.defaults.memorySearch.experimental.sessionMemory":
++    "Enable experimental session transcript indexing for memory search (default: false).",
++  "agents.defaults.memorySearch.provider":
++    'Embedding provider ("openai", "gemini", "voyage", or "local").',
++  "agents.defaults.memorySearch.remote.baseUrl":
++    "Custom base URL for remote embeddings (OpenAI-compatible proxies or Gemini overrides).",
++  "agents.defaults.memorySearch.remote.apiKey": "Custom API key for the remote embedding provider.",
++  "agents.defaults.memorySearch.remote.headers":
++    "Extra headers for remote embeddings (merged; remote overrides OpenAI headers).",
++  "agents.defaults.memorySearch.remote.batch.enabled":
++    "Enable batch API for memory embeddings (OpenAI/Gemini; default: true).",
++  "agents.defaults.memorySearch.remote.batch.wait":
++    "Wait for batch completion when indexing (default: true).",
++  "agents.defaults.memorySearch.remote.batch.concurrency":
++    "Max concurrent embedding batch jobs for memory indexing (default: 2).",
++  "agents.defaults.memorySearch.remote.batch.pollIntervalMs":
++    "Polling interval in ms for batch status (default: 2000).",
++  "agents.defaults.memorySearch.remote.batch.timeoutMinutes":
++    "Timeout in minutes for batch indexing (default: 60).",
++  "agents.defaults.memorySearch.local.modelPath":
++    "Local GGUF model path or hf: URI (node-llama-cpp).",
++  "agents.defaults.memorySearch.fallback":
++    'Fallback provider when embeddings fail ("openai", "gemini", "local", or "none").',
++  "agents.defaults.memorySearch.store.path":
++    "SQLite index path (default: ~/.openclaw/memory/{agentId}.sqlite).",
++  "agents.defaults.memorySearch.store.vector.enabled":
++    "Enable sqlite-vec extension for vector search (default: true).",
++  "agents.defaults.memorySearch.store.vector.extensionPath":
++    "Optional override path to sqlite-vec extension library (.dylib/.so/.dll).",
++  "agents.defaults.memorySearch.query.hybrid.enabled":
++    "Enable hybrid BM25 + vector search for memory (default: true).",
++  "agents.defaults.memorySearch.query.hybrid.vectorWeight":
++    "Weight for vector similarity when merging results (0-1).",
++  "agents.defaults.memorySearch.query.hybrid.textWeight":
++    "Weight for BM25 text relevance when merging results (0-1).",
++  "agents.defaults.memorySearch.query.hybrid.candidateMultiplier":
++    "Multiplier for candidate pool size (default: 4).",
++  "agents.defaults.memorySearch.cache.enabled":
++    "Cache chunk embeddings in SQLite to speed up reindexing and frequent updates (default: true).",
++  memory: "Memory backend configuration (global).",
++  "memory.backend": 'Memory backend ("builtin" for OpenClaw embeddings, "qmd" for QMD sidecar).',
++  "memory.citations": 'Default citation behavior ("auto", "on", or "off").',
++  "memory.qmd.command": "Path to the qmd binary (default: resolves from PATH).",
++  "memory.qmd.includeDefaultMemory":
++    "Whether to automatically index MEMORY.md + memory/**/*.md (default: true).",
++  "memory.qmd.paths":
++    "Additional directories/files to index with QMD (path + optional glob pattern).",
++  "memory.qmd.paths.path": "Absolute or ~-relative path to index via QMD.",
++  "memory.qmd.paths.pattern": "Glob pattern relative to the path root (default: **/*.md).",
++  "memory.qmd.paths.name":
++    "Optional stable name for the QMD collection (default derived from path).",
++  "memory.qmd.sessions.enabled":
++    "Enable QMD session transcript indexing (experimental, default: false).",
++  "memory.qmd.sessions.exportDir":
++    "Override directory for sanitized session exports before indexing.",
++  "memory.qmd.sessions.retentionDays":
++    "Retention window for exported sessions before pruning (default: unlimited).",
++  "memory.qmd.update.interval":
++    "How often the QMD sidecar refreshes indexes (duration string, default: 5m).",
++  "memory.qmd.update.debounceMs":
++    "Minimum delay between successive QMD refresh runs (default: 15000).",
++  "memory.qmd.update.onBoot": "Run QMD update once on gateway startup (default: true).",
++  "memory.qmd.update.embedInterval":
++    "How often QMD embeddings are refreshed (duration string, default: 60m). Set to 0 to disable periodic embed.",
++  "memory.qmd.limits.maxResults": "Max QMD results returned to the agent loop (default: 6).",
++  "memory.qmd.limits.maxSnippetChars": "Max characters per snippet pulled from QMD (default: 700).",
++  "memory.qmd.limits.maxInjectedChars": "Max total characters injected from QMD hits per turn.",
++  "memory.qmd.limits.timeoutMs": "Per-query timeout for QMD searches (default: 4000).",
++  "memory.qmd.scope":
++    "Session/channel scope for QMD recall (same syntax as session.sendPolicy; default: direct-only).",
++  "agents.defaults.memorySearch.cache.maxEntries":
++    "Optional cap on cached embeddings (best-effort).",
++  "agents.defaults.memorySearch.sync.onSearch":
++    "Lazy sync: schedule a reindex on search after changes.",
++  "agents.defaults.memorySearch.sync.watch": "Watch memory files for changes (chokidar).",
++  "agents.defaults.memorySearch.sync.sessions.deltaBytes":
++    "Minimum appended bytes before session transcripts trigger reindex (default: 100000).",
++  "agents.defaults.memorySearch.sync.sessions.deltaMessages":
++    "Minimum appended JSONL lines before session transcripts trigger reindex (default: 50).",
++  "plugins.enabled": "Enable plugin/extension loading (default: true).",
++  "plugins.allow": "Optional allowlist of plugin ids; when set, only listed plugins load.",
++  "plugins.deny": "Optional denylist of plugin ids; deny wins over allowlist.",
++  "plugins.load.paths": "Additional plugin files or directories to load.",
++  "plugins.slots": "Select which plugins own exclusive slots (memory, etc.).",
++  "plugins.slots.memory":
++    'Select the active memory plugin by id, or "none" to disable memory plugins.',
++  "plugins.entries": "Per-plugin settings keyed by plugin id (enable/disable + config payloads).",
++  "plugins.entries.*.enabled": "Overrides plugin enable/disable for this entry (restart required).",
++  "plugins.entries.*.config": "Plugin-defined config payload (schema is provided by the plugin).",
++  "plugins.installs":
++    "CLI-managed install metadata (used by `openclaw plugins update` to locate install sources).",
++  "plugins.installs.*.source": 'Install source ("npm", "archive", or "path").',
++  "plugins.installs.*.spec": "Original npm spec used for install (if source is npm).",
++  "plugins.installs.*.sourcePath": "Original archive/path used for install (if any).",
++  "plugins.installs.*.installPath":
++    "Resolved install directory (usually ~/.openclaw/extensions/<id>).",
++  "plugins.installs.*.version": "Version recorded at install time (if available).",
++  "plugins.installs.*.installedAt": "ISO timestamp of last install/update.",
++  "agents.list.*.identity.avatar":
++    "Agent avatar (workspace-relative path, http(s) URL, or data URI).",
++  "agents.defaults.model.primary": "Primary model (provider/model).",
++  "agents.defaults.model.fallbacks":
++    "Ordered fallback models (provider/model). Used when the primary model fails.",
++  "agents.defaults.imageModel.primary":
++    "Optional image model (provider/model) used when the primary model lacks image input.",
++  "agents.defaults.imageModel.fallbacks": "Ordered fallback image models (provider/model).",
++  "agents.defaults.cliBackends": "Optional CLI backends for text-only fallback (claude-cli, etc.).",
++  "agents.defaults.humanDelay.mode": 'Delay style for block replies ("off", "natural", "custom").',
++  "agents.defaults.humanDelay.minMs": "Minimum delay in ms for custom humanDelay (default: 800).",
++  "agents.defaults.humanDelay.maxMs": "Maximum delay in ms for custom humanDelay (default: 2500).",
++  "commands.native":
++    "Register native commands with channels that support it (Discord/Slack/Telegram).",
++  "commands.nativeSkills":
++    "Register native skill commands (user-invocable skills) with channels that support it.",
++  "commands.text": "Allow text command parsing (slash commands only).",
++  "commands.bash":
++    "Allow bash chat command (`!`; `/bash` alias) to run host shell commands (default: false; requires tools.elevated).",
++  "commands.bashForegroundMs":
++    "How long bash waits before backgrounding (default: 2000; 0 backgrounds immediately).",
++  "sessionPolicies.main.forbidLongExec":
++    "When true, blocks long-running exec calls from agent:*:main sessions (default: false).",
++  "sessionPolicies.main.requireBackgroundForExec":
++    "When true, main-session exec must use background mode when the guard is enabled (default: false).",
++  "sessionPolicies.main.maxExecTimeoutSec":
++    "Maximum timeout (seconds) allowed for main-session exec when the guard is enabled (default: 120).",
++  "commands.config": "Allow /config chat command to read/write config on disk (default: false).",
++  "commands.debug": "Allow /debug chat command for runtime-only overrides (default: false).",
++  "commands.restart": "Allow /restart and gateway restart tool actions (default: false).",
++  "commands.useAccessGroups": "Enforce access-group allowlists/policies for commands.",
++  "commands.ownerAllowFrom":
++    "Explicit owner allowlist for owner-only tools/commands. Use channel-native IDs (optionally prefixed like \"whatsapp:+15551234567\"). '*' is ignored.",
++  "session.dmScope":
++    'DM session scoping: "main" keeps continuity; "per-peer", "per-channel-peer", or "per-account-channel-peer" isolates DM history (recommended for shared inboxes/multi-account).',
++  "session.identityLinks":
++    "Map canonical identities to provider-prefixed peer IDs for DM session linking (example: telegram:123456).",
++  "channels.telegram.configWrites":
++    "Allow Telegram to write config in response to channel events/commands (default: true).",
++  "channels.slack.configWrites":
++    "Allow Slack to write config in response to channel events/commands (default: true).",
++  "channels.mattermost.configWrites":
++    "Allow Mattermost to write config in response to channel events/commands (default: true).",
++  "channels.discord.configWrites":
++    "Allow Discord to write config in response to channel events/commands (default: true).",
++  "channels.whatsapp.configWrites":
++    "Allow WhatsApp to write config in response to channel events/commands (default: true).",
++  "channels.signal.configWrites":
++    "Allow Signal to write config in response to channel events/commands (default: true).",
++  "channels.imessage.configWrites":
++    "Allow iMessage to write config in response to channel events/commands (default: true).",
++  "channels.msteams.configWrites":
++    "Allow Microsoft Teams to write config in response to channel events/commands (default: true).",
++  "channels.discord.commands.native": 'Override native commands for Discord (bool or "auto").',
++  "channels.discord.commands.nativeSkills":
++    'Override native skill commands for Discord (bool or "auto").',
++  "channels.telegram.commands.native": 'Override native commands for Telegram (bool or "auto").',
++  "channels.telegram.commands.nativeSkills":
++    'Override native skill commands for Telegram (bool or "auto").',
++  "channels.slack.commands.native": 'Override native commands for Slack (bool or "auto").',
++  "channels.slack.commands.nativeSkills":
++    'Override native skill commands for Slack (bool or "auto").',
++  "session.agentToAgent.maxPingPongTurns":
++    "Max reply-back turns between requester and target (0–5).",
++  "channels.telegram.customCommands":
++    "Additional Telegram bot menu commands (merged with native; conflicts ignored).",
++  "messages.ackReaction": "Emoji reaction used to acknowledge inbound messages (empty disables).",
++  "messages.ackReactionScope":
++    'When to send ack reactions ("group-mentions", "group-all", "direct", "all").',
++  "messages.inbound.debounceMs":
++    "Debounce window (ms) for batching rapid inbound messages from the same sender (0 to disable).",
++  "channels.telegram.dmPolicy":
++    'Direct message access control ("pairing" recommended). "open" requires channels.telegram.allowFrom=["*"].',
++  "channels.telegram.streamMode":
++    "Draft streaming mode for Telegram replies (off | partial | block). Separate from block streaming; requires private topics + sendMessageDraft.",
++  "channels.telegram.draftChunk.minChars":
++    'Minimum chars before emitting a Telegram draft update when channels.telegram.streamMode="block" (default: 200).',
++  "channels.telegram.draftChunk.maxChars":
++    'Target max size for a Telegram draft update chunk when channels.telegram.streamMode="block" (default: 800; clamped to channels.telegram.textChunkLimit).',
++  "channels.telegram.draftChunk.breakPreference":
++    "Preferred breakpoints for Telegram draft chunks (paragraph | newline | sentence). Default: paragraph.",
++  "channels.telegram.retry.attempts":
++    "Max retry attempts for outbound Telegram API calls (default: 3).",
++  "channels.telegram.retry.minDelayMs": "Minimum retry delay in ms for Telegram outbound calls.",
++  "channels.telegram.retry.maxDelayMs":
++    "Maximum retry delay cap in ms for Telegram outbound calls.",
++  "channels.telegram.retry.jitter": "Jitter factor (0-1) applied to Telegram retry delays.",
++  "channels.telegram.network.autoSelectFamily":
++    "Override Node autoSelectFamily for Telegram (true=enable, false=disable).",
++  "channels.telegram.timeoutSeconds":
++    "Max seconds before Telegram API requests are aborted (default: 500 per grammY).",
++  "channels.whatsapp.dmPolicy":
++    'Direct message access control ("pairing" recommended). "open" requires channels.whatsapp.allowFrom=["*"].',
++  "channels.whatsapp.selfChatMode": "Same-phone setup (bot uses your personal WhatsApp number).",
++  "channels.whatsapp.debounceMs":
++    "Debounce window (ms) for batching rapid consecutive messages from the same sender (0 to disable).",
++  "channels.signal.dmPolicy":
++    'Direct message access control ("pairing" recommended). "open" requires channels.signal.allowFrom=["*"].',
++  "channels.imessage.dmPolicy":
++    'Direct message access control ("pairing" recommended). "open" requires channels.imessage.allowFrom=["*"].',
++  "channels.bluebubbles.dmPolicy":
++    'Direct message access control ("pairing" recommended). "open" requires channels.bluebubbles.allowFrom=["*"].',
++  "channels.discord.dm.policy":
++    'Direct message access control ("pairing" recommended). "open" requires channels.discord.dm.allowFrom=["*"].',
++  "channels.discord.retry.attempts":
++    "Max retry attempts for outbound Discord API calls (default: 3).",
++  "channels.discord.retry.minDelayMs": "Minimum retry delay in ms for Discord outbound calls.",
++  "channels.discord.retry.maxDelayMs": "Maximum retry delay cap in ms for Discord outbound calls.",
++  "channels.discord.retry.jitter": "Jitter factor (0-1) applied to Discord retry delays.",
++  "channels.discord.maxLinesPerMessage": "Soft max line count per Discord message (default: 17).",
++  "channels.discord.intents.presence":
++    "Enable the Guild Presences privileged intent. Must also be enabled in the Discord Developer Portal. Allows tracking user activities (e.g. Spotify). Default: false.",
++  "channels.discord.intents.guildMembers":
++    "Enable the Guild Members privileged intent. Must also be enabled in the Discord Developer Portal. Default: false.",
++  "channels.discord.pluralkit.enabled":
++    "Resolve PluralKit proxied messages and treat system members as distinct senders.",
++  "channels.discord.pluralkit.token":
++    "Optional PluralKit token for resolving private systems or members.",
++  "channels.slack.dm.policy":
++    'Direct message access control ("pairing" recommended). "open" requires channels.slack.dm.allowFrom=["*"].',
++};
++
++const FIELD_PLACEHOLDERS: Record<string, string> = {
++  "gateway.remote.url": "ws://host:18789",
++  "gateway.remote.tlsFingerprint": "sha256:ab12cd34…",
++  "gateway.remote.sshTarget": "user@host",
++  "gateway.controlUi.basePath": "/openclaw",
++  "gateway.controlUi.root": "dist/control-ui",
++  "gateway.controlUi.allowedOrigins": "https://control.example.com",
++  "channels.mattermost.baseUrl": "https://chat.example.com",
++  "agents.list[].identity.avatar": "avatars/openclaw.png",
++};
++
++const SENSITIVE_PATTERNS = [/token/i, /password/i, /secret/i, /api.?key/i];
++
++function isSensitivePath(path: string): boolean {
++  return SENSITIVE_PATTERNS.some((pattern) => pattern.test(path));
++}
++
+ type JsonSchemaObject = JsonSchemaNode & {
+   type?: string | string[];
+   properties?: Record<string, JsonSchemaObject>;
+diff --git a/src/config/types.openclaw.ts b/src/config/types.openclaw.ts
+index 5b6b22402..eaae6c628 100644
+--- a/src/config/types.openclaw.ts
++++ b/src/config/types.openclaw.ts
+@@ -108,6 +108,13 @@ export type OpenClawConfig = {
+   talk?: TalkConfig;
+   gateway?: GatewayConfig;
+   memory?: MemoryConfig;
++  sessionPolicies?: {
++    main?: {
++      forbidLongExec?: boolean;
++      requireBackgroundForExec?: boolean;
++      maxExecTimeoutSec?: number;
++    };
++  };
+ };
+ 
+ export type ConfigValidationIssue = {
+diff --git a/src/config/zod-schema.ts b/src/config/zod-schema.ts
+index 3f1b89f98..0f2d202ed 100644
+--- a/src/config/zod-schema.ts
++++ b/src/config/zod-schema.ts
+@@ -316,6 +316,19 @@ export const OpenClawSchema = z
+     commands: CommandsSchema,
+     approvals: ApprovalsSchema,
+     session: SessionSchema,
++    sessionPolicies: z
++      .object({
++        main: z
++          .object({
++            forbidLongExec: z.boolean().optional(),
++            requireBackgroundForExec: z.boolean().optional(),
++            maxExecTimeoutSec: z.number().int().positive().optional(),
++          })
++          .strict()
++          .optional(),
++      })
++      .strict()
++      .optional(),
+     cron: z
+       .object({
+         enabled: z.boolean().optional(),

--- a/patches/45febecf2a2d-autocompat/0002-fix-resolve-cherry-pick-integration-for-main-session.patch
+++ b/patches/45febecf2a2d-autocompat/0002-fix-resolve-cherry-pick-integration-for-main-session.patch
@@ -1,0 +1,79 @@
+From a91b855c9c0871b691624042b41513606c0a3233 Mon Sep 17 00:00:00 2001
+From: zhaod <zhaod@local>
+Date: Fri, 20 Feb 2026 04:23:12 -0400
+Subject: [PATCH 02/16] fix: resolve cherry-pick integration for main-session
+ exec policy
+
+---
+ src/agents/pi-tools.ts | 14 +-------------
+ src/config/schema.ts   | 25 -------------------------
+ 2 files changed, 1 insertion(+), 38 deletions(-)
+
+diff --git a/src/agents/pi-tools.ts b/src/agents/pi-tools.ts
+index c6919e4b2..b68abfa4d 100644
+--- a/src/agents/pi-tools.ts
++++ b/src/agents/pi-tools.ts
+@@ -120,6 +120,7 @@ function resolveExecConfig(params: { cfg?: OpenClawConfig; agentId?: string }) {
+     notifyOnExitEmptySuccess:
+       agentExec?.notifyOnExitEmptySuccess ?? globalExec?.notifyOnExitEmptySuccess,
+     applyPatch: agentExec?.applyPatch ?? globalExec?.applyPatch,
++    mainSessionPolicy: cfg?.sessionPolicies?.main,
+   };
+ }
+ 
+@@ -157,19 +158,6 @@ export function resolveToolLoopDetectionConfig(params: {
+       ...global.detectors,
+       ...agent.detectors,
+     },
+-    host: globalExec?.host,
+-    security: globalExec?.security,
+-    ask: globalExec?.ask,
+-    node: globalExec?.node,
+-    pathPrepend: globalExec?.pathPrepend,
+-    safeBins: globalExec?.safeBins,
+-    backgroundMs: globalExec?.backgroundMs,
+-    timeoutSec: globalExec?.timeoutSec,
+-    approvalRunningNoticeMs: globalExec?.approvalRunningNoticeMs,
+-    cleanupMs: globalExec?.cleanupMs,
+-    notifyOnExit: globalExec?.notifyOnExit,
+-    applyPatch: globalExec?.applyPatch,
+-    mainSessionPolicy: cfg?.sessionPolicies?.main,
+   };
+ }
+ 
+diff --git a/src/config/schema.ts b/src/config/schema.ts
+index f30e4db02..024e8a6b9 100644
+--- a/src/config/schema.ts
++++ b/src/config/schema.ts
+@@ -824,31 +824,6 @@ function mergeObjectSchema(base: JsonSchemaObject, extension: JsonSchemaObject):
+   return merged;
+ }
+ 
+-export type ConfigSchemaResponse = {
+-  schema: ConfigSchema;
+-  uiHints: ConfigUiHints;
+-  version: string;
+-  generatedAt: string;
+-};
+-
+-export type PluginUiMetadata = {
+-  id: string;
+-  name?: string;
+-  description?: string;
+-  configUiHints?: Record<
+-    string,
+-    Pick<ConfigUiHint, "label" | "help" | "tags" | "advanced" | "sensitive" | "placeholder">
+-  >;
+-  configSchema?: JsonSchemaNode;
+-};
+-
+-export type ChannelUiMetadata = {
+-  id: string;
+-  label?: string;
+-  description?: string;
+-  configSchema?: JsonSchemaNode;
+-  configUiHints?: Record<string, ConfigUiHint>;
+-};
+ 
+ function collectExtensionHintKeys(
+   hints: ConfigUiHints,

--- a/patches/45febecf2a2d-autocompat/0003-telegram-route-status-and-stop-to-control-sequential.patch
+++ b/patches/45febecf2a2d-autocompat/0003-telegram-route-status-and-stop-to-control-sequential.patch
@@ -1,0 +1,61 @@
+From f1303d0e406bbe647fafd5279d7b438d9b1b9941 Mon Sep 17 00:00:00 2001
+From: zhaod <zhaod@local>
+Date: Fri, 20 Feb 2026 12:57:41 -0400
+Subject: [PATCH 03/16] telegram: route /status and /stop to control sequential
+ lane
+
+---
+ src/telegram/bot.create-telegram-bot.test.ts | 10 ++++++++--
+ src/telegram/bot.ts                          |  8 +++++++-
+ 2 files changed, 15 insertions(+), 3 deletions(-)
+
+diff --git a/src/telegram/bot.create-telegram-bot.test.ts b/src/telegram/bot.create-telegram-bot.test.ts
+index fdd2eb32e..913a855ba 100644
+--- a/src/telegram/bot.create-telegram-bot.test.ts
++++ b/src/telegram/bot.create-telegram-bot.test.ts
+@@ -1,7 +1,7 @@
+ import fs from "node:fs";
+ import os from "node:os";
+ import path from "node:path";
+-import type { Chat, Message } from "@grammyjs/types";
++import type { Chat, Message, UserFromGetMe } from "@grammyjs/types";
+ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+ import { escapeRegExp, formatEnvelopeTimestamp } from "../../test/helpers/envelope-timestamp.js";
+ import { withEnvAsync } from "../test-utils/env.js";
+@@ -173,7 +173,13 @@ describe("createTelegramBot", () => {
+       getTelegramSequentialKey({
+         message: mockMessage({ chat: mockChat({ id: 123 }), text: "/status" }),
+       }),
+-    ).toBe("telegram:123");
++    ).toBe("telegram:123:control");
++    expect(
++      getTelegramSequentialKey({
++        me: { username: "openclaw" } as UserFromGetMe,
++        message: mockMessage({ chat: mockChat({ id: 123 }), text: "/status@openclaw" }),
++      }),
++    ).toBe("telegram:123:control");
+     expect(
+       getTelegramSequentialKey({
+         message: mockMessage({ chat: mockChat({ id: 123 }), text: "stop" }),
+diff --git a/src/telegram/bot.ts b/src/telegram/bot.ts
+index 438ed1c9b..e585e9dd1 100644
+--- a/src/telegram/bot.ts
++++ b/src/telegram/bot.ts
+@@ -94,10 +94,16 @@ export function getTelegramSequentialKey(ctx: {
+   const chatId = msg?.chat?.id ?? ctx.chat?.id;
+   const rawText = msg?.text ?? msg?.caption;
+   const botUsername = ctx.me?.username;
+-  if (isAbortRequestText(rawText, botUsername ? { botUsername } : undefined)) {
++  const normalizedText = (rawText ?? "").trim().toLowerCase();
++  const isStatusCommand =
++    normalizedText === "/status" ||
++    (botUsername ? normalizedText === `/status@${botUsername.toLowerCase()}` : false);
++  const isStopCommand = isAbortRequestText(rawText, botUsername ? { botUsername } : undefined);
++  if (isStopCommand || isStatusCommand) {
+     if (typeof chatId === "number") {
+       return `telegram:${chatId}:control`;
+     }
++    logVerbose("telegram: control command received without numeric chat id; using fallback control lane");
+     return "telegram:control";
+   }
+   const isGroup = msg?.chat?.type === "group" || msg?.chat?.type === "supergroup";

--- a/patches/45febecf2a2d-autocompat/0004-scripts-add-install-personal-helper-for-113-deploy.patch
+++ b/patches/45febecf2a2d-autocompat/0004-scripts-add-install-personal-helper-for-113-deploy.patch
@@ -1,0 +1,48 @@
+From 57aa49bc5e420d139edabbd40312de7561e94273 Mon Sep 17 00:00:00 2001
+From: zhaod <zhaod@local>
+Date: Fri, 20 Feb 2026 13:03:55 -0400
+Subject: [PATCH 04/16] scripts: add install-personal helper for 113 deploy
+
+---
+ scripts/install-personal.sh | 32 ++++++++++++++++++++++++++++++++
+ 1 file changed, 32 insertions(+)
+ create mode 100755 scripts/install-personal.sh
+
+diff --git a/scripts/install-personal.sh b/scripts/install-personal.sh
+new file mode 100755
+index 000000000..01bbd5520
+--- /dev/null
++++ b/scripts/install-personal.sh
+@@ -0,0 +1,32 @@
++#!/usr/bin/env bash
++set -euo pipefail
++
++REPO_DIR=${1:-/home/ubuntu/openclaw-src}
++BRANCH=${2:-personal}
++
++if ! command -v pnpm >/dev/null 2>&1; then
++  echo "pnpm is required" >&2
++  exit 1
++fi
++
++echo "[1/6] fetch branch ${BRANCH}"
++git -C "$REPO_DIR" fetch origin "$BRANCH"
++
++echo "[2/6] checkout/reset to origin/${BRANCH}"
++git -C "$REPO_DIR" checkout "$BRANCH"
++git -C "$REPO_DIR" reset --hard "origin/$BRANCH"
++
++echo "[3/6] install deps"
++pnpm -C "$REPO_DIR" install --frozen-lockfile
++
++echo "[4/6] build"
++pnpm -C "$REPO_DIR" -s build
++
++echo "[5/6] restart gateway"
++node "$REPO_DIR/dist/entry.js" gateway restart || true
++
++echo "[6/6] probe"
++node "$REPO_DIR/dist/entry.js" gateway probe
++node "$REPO_DIR/dist/entry.js" channels status --probe || true
++
++echo "done: ${BRANCH} installed from $REPO_DIR"

--- a/patches/45febecf2a2d-autocompat/0005-telegram-fast-path-stop-and-status-in-ingress-contro.patch
+++ b/patches/45febecf2a2d-autocompat/0005-telegram-fast-path-stop-and-status-in-ingress-contro.patch
@@ -1,0 +1,194 @@
+From ebcf771b42781b252ab057e068d584481f41db3b Mon Sep 17 00:00:00 2001
+From: zhaod <zhaod@local>
+Date: Fri, 20 Feb 2026 13:32:40 -0400
+Subject: [PATCH 05/16] telegram: fast-path /stop and /status in ingress
+ control lane
+
+---
+ src/telegram/bot-handlers.ts | 121 ++++++++++++++++++++++++++++++++++-
+ 1 file changed, 120 insertions(+), 1 deletion(-)
+
+diff --git a/src/telegram/bot-handlers.ts b/src/telegram/bot-handlers.ts
+index 5d3cfc30b..6d472cfa3 100644
+--- a/src/telegram/bot-handlers.ts
++++ b/src/telegram/bot-handlers.ts
+@@ -1,10 +1,12 @@
+ import type { Message, ReactionTypeEmoji } from "@grammyjs/types";
+-import { resolveAgentDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
++import { resolveAgentDir, resolveDefaultAgentId, resolveSessionAgentId } from "../agents/agent-scope.js";
+ import { hasControlCommand } from "../auto-reply/command-detection.js";
++import { normalizeCommandBody } from "../auto-reply/commands-registry.js";
+ import {
+   createInboundDebouncer,
+   resolveInboundDebounceMs,
+ } from "../auto-reply/inbound-debounce.js";
++import { formatAbortReplyText, stopSubagentsForRequester } from "../auto-reply/reply/abort.js";
+ import { buildCommandsPaginationKeyboard } from "../auto-reply/reply/commands-info.js";
+ import {
+   buildModelsProviderData,
+@@ -13,6 +15,7 @@ import {
+ import { resolveStoredModelOverride } from "../auto-reply/reply/model-selection.js";
+ import { listSkillCommandsForAgents } from "../auto-reply/skill-commands.js";
+ import { buildCommandsMessagePaginated } from "../auto-reply/status.js";
++import { clearSessionQueues } from "../auto-reply/reply/queue.js";
+ import { resolveChannelConfigWrites } from "../channels/plugins/config-writes.js";
+ import { loadConfig } from "../config/config.js";
+ import { writeConfigFile } from "../config/io.js";
+@@ -22,6 +25,9 @@ import { danger, logVerbose, warn } from "../globals.js";
+ import { enqueueSystemEvent } from "../infra/system-events.js";
+ import { MediaFetchError } from "../media/fetch.js";
+ import { readChannelAllowFromStore } from "../pairing/pairing-store.js";
++import { abortEmbeddedPiRun } from "../agents/pi-embedded.js";
++import { createSessionStatusTool } from "../agents/tools/session-status-tool.js";
++import type { MsgContext } from "../auto-reply/templating.js";
+ import { resolveAgentRoute } from "../routing/resolve-route.js";
+ import { resolveThreadSessionKeys } from "../routing/session-key.js";
+ import { withTelegramApiErrorLogging } from "./api-logging.js";
+@@ -226,6 +232,8 @@ export const registerTelegramHandlers = ({
+     resolvedThreadId?: number;
+   }): {
+     agentId: string;
++    sessionKey: string;
++    storePath: string;
+     sessionEntry: ReturnType<typeof loadSessionStore>[string];
+     model?: string;
+   } => {
+@@ -271,6 +279,8 @@ export const registerTelegramHandlers = ({
+     if (storedOverride) {
+       return {
+         agentId: route.agentId,
++        sessionKey,
++        storePath,
+         sessionEntry: entry,
+         model: storedOverride.provider
+           ? `${storedOverride.provider}/${storedOverride.model}`
+@@ -282,6 +292,8 @@ export const registerTelegramHandlers = ({
+     if (provider && model) {
+       return {
+         agentId: route.agentId,
++        sessionKey,
++        storePath,
+         sessionEntry: entry,
+         model: `${provider}/${model}`,
+       };
+@@ -289,6 +301,8 @@ export const registerTelegramHandlers = ({
+     const modelCfg = cfg.agents?.defaults?.model;
+     return {
+       agentId: route.agentId,
++      sessionKey,
++      storePath,
+       sessionEntry: entry,
+       model: typeof modelCfg === "string" ? modelCfg : modelCfg?.primary,
+     };
+@@ -607,6 +621,111 @@ export const registerTelegramHandlers = ({
+       oversizeLogMessage,
+     } = params;
+ 
++    const inboundText = (msg.text ?? msg.caption ?? "").trim();
++    const normalizedControlCommand = normalizeCommandBody(inboundText, {
++      botUsername: ctx.me?.username,
++    })
++      .trim()
++      .toLowerCase();
++    if (normalizedControlCommand === "/stop" || normalizedControlCommand === "/status") {
++      logger.info(
++        {
++          marker: "command_ingress",
++          command: normalizedControlCommand,
++          chatId,
++          messageId: msg.message_id,
++        },
++        "command_ingress",
++      );
++      const isGroup = msg.chat.type === "group" || msg.chat.type === "supergroup";
++      const isForum = msg.chat.is_forum === true;
++      const sessionState = resolveTelegramSessionState({
++        chatId,
++        isGroup,
++        isForum,
++        messageThreadId: msg.message_thread_id,
++        resolvedThreadId,
++      });
++      logger.info(
++        {
++          marker: "control_lane_dequeue",
++          command: normalizedControlCommand,
++          sessionKey: sessionState.sessionKey,
++          agentId: sessionState.agentId,
++        },
++        "control_lane_dequeue",
++      );
++      const replyParams = {
++        reply_to_message_id: msg.message_id,
++        ...(msg.message_thread_id != null ? { message_thread_id: msg.message_thread_id } : {}),
++      };
++      if (normalizedControlCommand === "/stop") {
++        const sessionId = sessionState.sessionEntry?.sessionId;
++        const aborted = sessionId ? abortEmbeddedPiRun(sessionId) : false;
++        const cleared = clearSessionQueues([sessionState.sessionKey, sessionId]);
++        const { stopped } = stopSubagentsForRequester({
++          cfg,
++          requesterSessionKey: sessionState.sessionKey,
++        });
++        const agentId = resolveSessionAgentId({
++          sessionKey: sessionState.sessionKey,
++          config: cfg,
++        });
++        await withTelegramApiErrorLogging({
++          operation: "sendMessage",
++          runtime,
++          fn: () => bot.api.sendMessage(chatId, formatAbortReplyText(stopped), replyParams),
++        }).catch(() => {});
++        logger.info(
++          {
++            marker: "abort_dispatched",
++            command: normalizedControlCommand,
++            sessionKey: sessionState.sessionKey,
++            agentId,
++            sessionId,
++            aborted,
++            laneCleared: cleared.laneCleared,
++            followupCleared: cleared.followupCleared,
++            stoppedSubagents: stopped,
++          },
++          "abort_dispatched",
++        );
++        return;
++      }
++
++      const statusTool = createSessionStatusTool({
++        agentSessionKey: sessionState.sessionKey,
++        config: cfg,
++      });
++      let statusText = "⚠️ Status unavailable.";
++      try {
++        const statusResult = await statusTool.execute("telegram-local-status", {
++          sessionKey: sessionState.sessionKey,
++        });
++        const textPart = statusResult?.content?.find((part) => part.type === "text");
++        if (textPart?.text?.trim()) {
++          statusText = textPart.text;
++        }
++      } catch (statusErr) {
++        statusText = `⚠️ Status unavailable: ${String(statusErr)}`;
++      }
++      await withTelegramApiErrorLogging({
++        operation: "sendMessage",
++        runtime,
++        fn: () => bot.api.sendMessage(chatId, statusText, replyParams),
++      }).catch(() => {});
++      logger.info(
++        {
++          marker: "status_replied",
++          command: normalizedControlCommand,
++          sessionKey: sessionState.sessionKey,
++          textLength: statusText.length,
++        },
++        "status_replied",
++      );
++      return;
++    }
++
+     // Text fragment handling - Telegram splits long pastes into multiple inbound messages (~4096 chars).
+     // We buffer “near-limit” messages and append immediately-following parts.
+     const text = typeof msg.text === "string" ? msg.text : undefined;

--- a/patches/45febecf2a2d-autocompat/0006-fix-make-transient-retry-delay-abortable.patch
+++ b/patches/45febecf2a2d-autocompat/0006-fix-make-transient-retry-delay-abortable.patch
@@ -1,0 +1,118 @@
+From 5966b3e05ebc3fa3fcb844686ef96f458f6fe91e Mon Sep 17 00:00:00 2001
+From: zhaod <zhaod@local>
+Date: Fri, 20 Feb 2026 14:47:35 -0400
+Subject: [PATCH 06/16] fix: make transient retry delay abortable
+
+---
+ .../reply/agent-runner-execution.ts           | 13 ++--
+ .../agent-runner.misc.runreplyagent.test.ts   | 69 +++++++++++++++++++
+ 2 files changed, 78 insertions(+), 4 deletions(-)
+
+diff --git a/src/auto-reply/reply/agent-runner-execution.ts b/src/auto-reply/reply/agent-runner-execution.ts
+index eaabfe2f2..c9db1be78 100644
+--- a/src/auto-reply/reply/agent-runner-execution.ts
++++ b/src/auto-reply/reply/agent-runner-execution.ts
+@@ -1,5 +1,6 @@
+ import crypto from "node:crypto";
+ import fs from "node:fs";
++import { setTimeout as delay } from "node:timers/promises";
+ import { runCliAgent } from "../../agents/cli-runner.js";
+ import { getCliSessionId } from "../../agents/cli-session.js";
+ import { runWithModelFallback } from "../../agents/model-fallback.js";
+@@ -546,10 +547,14 @@ export async function runAgentTurnWithFallback(params: {
+         defaultRuntime.error(
+           `Transient HTTP provider error before reply (${message}). Retrying once in ${TRANSIENT_HTTP_RETRY_DELAY_MS}ms.`,
+         );
+-        await new Promise<void>((resolve) => {
+-          setTimeout(resolve, TRANSIENT_HTTP_RETRY_DELAY_MS);
+-        });
+-        continue;
++        try {
++          await delay(TRANSIENT_HTTP_RETRY_DELAY_MS, undefined, {
++            signal: params.opts?.abortSignal,
++          });
++          continue;
++        } catch {
++          // Abort should short-circuit the retry wait and fall through to final error handling.
++        }
+       }
+ 
+       defaultRuntime.error(`Embedded agent failed before reply: ${message}`);
+diff --git a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+index 5d0465552..d18299cc2 100644
+--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
++++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+@@ -1409,4 +1409,73 @@ describe("runReplyAgent transient HTTP retry", () => {
+     const payload = Array.isArray(result) ? result[0] : result;
+     expect(payload?.text).toContain("Recovered response");
+   });
++
++  it("aborts transient retry delay immediately when abort signal fires", async () => {
++    vi.useFakeTimers();
++    runEmbeddedPiAgentMock.mockRejectedValueOnce(new Error("521 Cloudflare"));
++
++    const typing = createMockTypingController();
++    const sessionCtx = {
++      Provider: "telegram",
++      MessageSid: "msg",
++    } as unknown as TemplateContext;
++    const resolvedQueue = { mode: "interrupt" } as unknown as QueueSettings;
++    const followupRun = {
++      prompt: "hello",
++      summaryLine: "hello",
++      enqueuedAt: Date.now(),
++      run: {
++        sessionId: "session",
++        sessionKey: "main",
++        messageProvider: "telegram",
++        sessionFile: "/tmp/session.jsonl",
++        workspaceDir: "/tmp",
++        config: {},
++        skillsSnapshot: {},
++        provider: "anthropic",
++        model: "claude",
++        thinkLevel: "low",
++        verboseLevel: "off",
++        elevatedLevel: "off",
++        bashElevated: {
++          enabled: false,
++          allowed: false,
++          defaultLevel: "off",
++        },
++        timeoutMs: 1_000,
++        blockReplyBreak: "message_end",
++      },
++    } as unknown as FollowupRun;
++
++    const abort = new AbortController();
++    const runPromise = runReplyAgent({
++      commandBody: "hello",
++      followupRun,
++      queueKey: "main",
++      resolvedQueue,
++      shouldSteer: false,
++      shouldFollowup: false,
++      isActive: false,
++      isStreaming: false,
++      typing,
++      sessionCtx,
++      opts: { abortSignal: abort.signal },
++      defaultModel: "anthropic/claude-opus-4-5",
++      resolvedVerboseLevel: "off",
++      isNewSession: false,
++      blockStreamingEnabled: false,
++      resolvedBlockStreamingBreak: "message_end",
++      shouldInjectGroupIntro: false,
++      typingMode: "instant",
++    });
++
++    abort.abort(new Error("manual abort"));
++    await vi.advanceTimersByTimeAsync(1);
++    const result = await runPromise;
++
++    expect(runEmbeddedPiAgentMock).toHaveBeenCalledTimes(1);
++    const payload = Array.isArray(result) ? result[0] : result;
++    expect(String(payload?.text ?? "")).toContain("Agent failed before reply");
++  });
++
+ });

--- a/patches/45febecf2a2d-autocompat/0007-fix-control-isolate-stop-status-on-dedicated-control.patch
+++ b/patches/45febecf2a2d-autocompat/0007-fix-control-isolate-stop-status-on-dedicated-control.patch
@@ -1,0 +1,346 @@
+From 959ad23e9819b75a36f89d9c57c6c961a57beb53 Mon Sep 17 00:00:00 2001
+From: zhaod <zhaod@local>
+Date: Fri, 20 Feb 2026 15:07:52 -0400
+Subject: [PATCH 07/16] fix(control): isolate /stop /status on dedicated
+ control lane
+
+---
+ .../reply/dispatch-from-config.test.ts        |  61 ++++++-
+ src/auto-reply/reply/dispatch-from-config.ts  | 167 +++++++++++++++++-
+ src/infra/diagnostic-events.ts                |  11 +-
+ src/process/lanes.ts                          |   1 +
+ 4 files changed, 237 insertions(+), 3 deletions(-)
+
+diff --git a/src/auto-reply/reply/dispatch-from-config.test.ts b/src/auto-reply/reply/dispatch-from-config.test.ts
+index 2a69f506a..8c2012872 100644
+--- a/src/auto-reply/reply/dispatch-from-config.test.ts
++++ b/src/auto-reply/reply/dispatch-from-config.test.ts
+@@ -19,6 +19,8 @@ const diagnosticMocks = vi.hoisted(() => ({
+   logMessageQueued: vi.fn(),
+   logMessageProcessed: vi.fn(),
+   logSessionStateChange: vi.fn(),
++  logLaneEnqueue: vi.fn(),
++  logLaneDequeue: vi.fn(),
+ }));
+ const hookMocks = vi.hoisted(() => ({
+   runner: {
+@@ -51,10 +53,16 @@ vi.mock("./abort.js", () => ({
+   },
+ }));
+ 
++vi.mock("../../process/command-queue.js", () => ({
++  enqueueCommandInLane: vi.fn(async (_lane: string, task: () => Promise<unknown>) => await task()),
++}));
++
+ vi.mock("../../logging/diagnostic.js", () => ({
+   logMessageQueued: diagnosticMocks.logMessageQueued,
+   logMessageProcessed: diagnosticMocks.logMessageProcessed,
+   logSessionStateChange: diagnosticMocks.logSessionStateChange,
++  logLaneEnqueue: diagnosticMocks.logLaneEnqueue,
++  logLaneDequeue: diagnosticMocks.logLaneDequeue,
+ }));
+ 
+ vi.mock("../../plugins/hook-runner-global.js", () => ({
+@@ -65,7 +73,7 @@ vi.mock("../../hooks/internal-hooks.js", () => ({
+   triggerInternalHook: internalHookMocks.triggerInternalHook,
+ }));
+ 
+-const { dispatchReplyFromConfig } = await import("./dispatch-from-config.js");
++const { dispatchReplyFromConfig, matchStrictControlCommand } = await import("./dispatch-from-config.js");
+ const { resetInboundDedupe } = await import("./inbound-dedupe.js");
+ 
+ const noAbortResult = { handled: false, aborted: false } as const;
+@@ -538,4 +546,55 @@ describe("dispatchReplyFromConfig", () => {
+       }),
+     );
+   });
++
++  it("matches only full /stop and /status commands", () => {
++    expect(matchStrictControlCommand(" /stop ")).toBe("stop");
++    expect(matchStrictControlCommand("/status@openclaw_bot")).toBe("status");
++    expect(matchStrictControlCommand("hey /stop")).toBeNull();
++    expect(matchStrictControlCommand("/status now")).toBeNull();
++    expect(matchStrictControlCommand("/stop please")).toBeNull();
++  });
++
++  it("handles /status in control lane without invoking model resolver", async () => {
++    setNoAbort();
++    const dispatcher = createDispatcher();
++    const ctx = buildTestCtx({
++      Provider: "slack",
++      Surface: "slack",
++      CommandBody: "/status",
++      RawBody: "/status",
++      Body: "/status",
++    });
++    const replyResolver = vi.fn(async () => {
++      throw new Error("model unavailable");
++    });
++
++    const result = await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
++
++    expect(replyResolver).not.toHaveBeenCalled();
++    expect(dispatcher.sendFinalReply).toHaveBeenCalled();
++    expect(result.queuedFinal).toBe(true);
++  });
++
++  it("times out /stop abort dispatch and replies with timeout reason", async () => {
++    mocks.tryFastAbortFromMessage.mockImplementation(
++      () => new Promise<AbortResult>(() => undefined),
++    );
++    const dispatcher = createDispatcher();
++    const ctx = buildTestCtx({
++      Provider: "slack",
++      Surface: "slack",
++      CommandBody: "/stop",
++      RawBody: "/stop",
++      Body: "/stop",
++    });
++
++    await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher });
++
++    const calls = (dispatcher.sendFinalReply as ReturnType<typeof vi.fn>).mock.calls;
++    expect(calls.length).toBeGreaterThanOrEqual(2);
++    expect(String(calls[0]?.[0]?.text ?? "")).toContain("Stopping");
++    expect(String(calls[calls.length - 1]?.[0]?.text ?? "")).toContain("timeout");
++  }, 10000);
++
+ });
+diff --git a/src/auto-reply/reply/dispatch-from-config.ts b/src/auto-reply/reply/dispatch-from-config.ts
+index e4e66c16a..009fab046 100644
+--- a/src/auto-reply/reply/dispatch-from-config.ts
++++ b/src/auto-reply/reply/dispatch-from-config.ts
+@@ -3,13 +3,15 @@ import type { OpenClawConfig } from "../../config/config.js";
+ import { loadSessionStore, resolveStorePath } from "../../config/sessions.js";
+ import { logVerbose } from "../../globals.js";
+ import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
+-import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
++import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
+ import {
+   logMessageProcessed,
+   logMessageQueued,
+   logSessionStateChange,
+ } from "../../logging/diagnostic.js";
+ import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
++import { enqueueCommandInLane } from "../../process/command-queue.js";
++import { CommandLane } from "../../process/lanes.js";
+ import { maybeApplyTtsToPayload, normalizeTtsAutoMode, resolveTtsConfig } from "../../tts/tts.js";
+ import { getReplyFromConfig } from "../reply.js";
+ import type { FinalizedMsgContext } from "../templating.js";
+@@ -54,6 +56,63 @@ const isInboundAudioContext = (ctx: FinalizedMsgContext): boolean => {
+   return AUDIO_HEADER_RE.test(trimmed);
+ };
+ 
++
++const STRICT_CONTROL_COMMAND_RE = /^\s*\/(stop|status)(?:@[\w_]+)?\s*$/i;
++const CONTROL_ACK_TIMEOUT_MS = 1_000;
++const CONTROL_ABORT_DISPATCH_TIMEOUT_MS = 3_000;
++
++export function matchStrictControlCommand(text?: string): "stop" | "status" | null {
++  if (!text) {
++    return null;
++  }
++  const match = text.match(STRICT_CONTROL_COMMAND_RE);
++  if (!match) {
++    return null;
++  }
++  const command = match[1]?.toLowerCase();
++  return command === "stop" || command === "status" ? command : null;
++}
++
++function createAbortError(): Error {
++  const err = new Error("control command aborted");
++  err.name = "AbortError";
++  return err;
++}
++
++async function runWithTimeout<T>(params: {
++  timeoutMs: number;
++  signal?: AbortSignal;
++  run: (signal: AbortSignal) => Promise<T>;
++}): Promise<T> {
++  if (params.signal?.aborted) {
++    throw createAbortError();
++  }
++  const controller = new AbortController();
++  const onAbort = () => controller.abort();
++  params.signal?.addEventListener("abort", onAbort, { once: true });
++  const timeout = setTimeout(() => controller.abort(), params.timeoutMs);
++  try {
++    const runPromise = params.run(controller.signal);
++    const abortPromise = new Promise<never>((_, reject) => {
++      controller.signal.addEventListener(
++        "abort",
++        () => {
++          if (params.signal?.aborted) {
++            reject(createAbortError());
++            return;
++          }
++          reject(new Error(`timeout ${params.timeoutMs}ms`));
++        },
++        { once: true },
++      );
++    });
++    return await Promise.race([runPromise, abortPromise]);
++  } finally {
++    clearTimeout(timeout);
++    params.signal?.removeEventListener("abort", onAbort);
++  }
++}
++
+ const resolveSessionTtsAuto = (
+   ctx: FinalizedMsgContext,
+   cfg: OpenClawConfig,
+@@ -275,6 +334,112 @@ export async function dispatchReplyFromConfig(params: {
+     }
+   };
+ 
++  const ingressBody = ctx.CommandBody ?? ctx.RawBody ?? ctx.Body;
++  const strictControlCommand = matchStrictControlCommand(ingressBody);
++  if (strictControlCommand) {
++    emitDiagnosticEvent({
++      type: "command_ingress",
++      sessionKey: ctx.SessionKey,
++      command: strictControlCommand,
++    });
++
++    const controlResult = await enqueueCommandInLane(CommandLane.Control, async () => {
++      emitDiagnosticEvent({
++        type: "control_dequeue",
++        sessionKey: ctx.SessionKey,
++        command: strictControlCommand,
++      });
++
++      const emitPayload = async (payload: ReplyPayload, signal?: AbortSignal): Promise<boolean> => {
++        if (shouldRouteToOriginating && originatingChannel && originatingTo) {
++          const result = await routeReply({
++            payload,
++            channel: originatingChannel,
++            to: originatingTo,
++            sessionKey: ctx.SessionKey,
++            accountId: ctx.AccountId,
++            threadId: ctx.MessageThreadId,
++            cfg,
++            abortSignal: signal,
++          });
++          return result.ok;
++        }
++        return dispatcher.sendFinalReply(payload);
++      };
++
++      let queuedFinal = false;
++      const counts = dispatcher.getQueuedCounts();
++
++      if (strictControlCommand === "stop") {
++        const ackOk = await runWithTimeout({
++          timeoutMs: CONTROL_ACK_TIMEOUT_MS,
++          run: (signal) => emitPayload({ text: "Stopping..." }, signal),
++        });
++        if (ackOk) {
++          counts.final += 1;
++          emitDiagnosticEvent({
++            type: "ack_sent",
++            sessionKey: ctx.SessionKey,
++            command: "stop",
++          });
++        }
++
++        try {
++          const fastAbort = await runWithTimeout({
++            timeoutMs: CONTROL_ABORT_DISPATCH_TIMEOUT_MS,
++            run: () => tryFastAbortFromMessage({ ctx, cfg }),
++          });
++          emitDiagnosticEvent({
++            type: "abort_dispatched",
++            sessionKey: ctx.SessionKey,
++            command: "stop",
++            handled: fastAbort.handled,
++          });
++          const doneText = fastAbort.handled
++            ? formatAbortReplyText(fastAbort.stoppedSubagents)
++            : "⚠️ Stop request was not applied (not authorized or no active target).";
++          queuedFinal = await emitPayload({ text: doneText });
++          if (queuedFinal) {
++            counts.final += 1;
++          }
++        } catch (err) {
++          const reason = String(err);
++          queuedFinal = await emitPayload({
++            text: `⚠️ Stop failed: ${reason.includes("timeout") ? "abort dispatch timeout (3s)" : reason}`,
++          });
++          if (queuedFinal) {
++            counts.final += 1;
++          }
++        }
++
++        return { queuedFinal, counts };
++      }
++
++      const statusOk = await runWithTimeout({
++        timeoutMs: CONTROL_ACK_TIMEOUT_MS,
++        run: (signal) =>
++          emitPayload(
++            {
++              text: "✅ Status: control plane is responsive.",
++            },
++            signal,
++          ),
++      });
++      if (statusOk) {
++        counts.final += 1;
++        emitDiagnosticEvent({
++          type: "status_replied",
++          sessionKey: ctx.SessionKey,
++          command: "status",
++        });
++      }
++      return { queuedFinal: statusOk, counts };
++    });
++
++    recordProcessed("completed", { reason: `control_${strictControlCommand}` });
++    return controlResult;
++  }
++
+   markProcessing();
+ 
+   try {
+diff --git a/src/infra/diagnostic-events.ts b/src/infra/diagnostic-events.ts
+index 5acf0483a..6db61e499 100644
+--- a/src/infra/diagnostic-events.ts
++++ b/src/infra/diagnostic-events.ts
+@@ -134,6 +134,14 @@ export type DiagnosticHeartbeatEvent = DiagnosticBaseEvent & {
+   queued: number;
+ };
+ 
++
++export type DiagnosticControlCommandEvent = DiagnosticBaseEvent & {
++  type: "command_ingress" | "control_dequeue" | "ack_sent" | "abort_dispatched" | "status_replied";
++  sessionKey?: string;
++  command: "stop" | "status";
++  handled?: boolean;
++};
++
+ export type DiagnosticToolLoopEvent = DiagnosticBaseEvent & {
+   type: "tool.loop";
+   sessionKey?: string;
+@@ -160,7 +168,8 @@ export type DiagnosticEventPayload =
+   | DiagnosticLaneDequeueEvent
+   | DiagnosticRunAttemptEvent
+   | DiagnosticHeartbeatEvent
+-  | DiagnosticToolLoopEvent;
++  | DiagnosticToolLoopEvent
++  | DiagnosticControlCommandEvent;
+ 
+ export type DiagnosticEventInput = DiagnosticEventPayload extends infer Event
+   ? Event extends DiagnosticEventPayload
+diff --git a/src/process/lanes.ts b/src/process/lanes.ts
+index 63ef1f534..512aec04c 100644
+--- a/src/process/lanes.ts
++++ b/src/process/lanes.ts
+@@ -1,5 +1,6 @@
+ export const enum CommandLane {
+   Main = "main",
++  Control = "control",
+   Cron = "cron",
+   Subagent = "subagent",
+   Nested = "nested",

--- a/patches/45febecf2a2d-autocompat/0008-feat-control-plane-route-stop-and-status-via-durable.patch
+++ b/patches/45febecf2a2d-autocompat/0008-feat-control-plane-route-stop-and-status-via-durable.patch
@@ -1,0 +1,638 @@
+From d8fb89aeb042858f5560832776405478b4d65455 Mon Sep 17 00:00:00 2001
+From: dddabtc <zhaodali78@gmail.com>
+Date: Fri, 20 Feb 2026 17:19:38 -0400
+Subject: [PATCH 08/16] feat(control-plane): route /stop and /status via
+ durable control plane
+
+---
+ scripts/control-plane-benchmark.ts            |  98 ++++++
+ src/auto-reply/control-plane.test.ts          | 124 +++++++
+ src/auto-reply/control-plane.ts               | 324 ++++++++++++++++++
+ .../reply/dispatch-from-config.test.ts        |  19 +
+ src/auto-reply/reply/dispatch-from-config.ts  |   9 +
+ 5 files changed, 574 insertions(+)
+ create mode 100644 scripts/control-plane-benchmark.ts
+ create mode 100644 src/auto-reply/control-plane.test.ts
+ create mode 100644 src/auto-reply/control-plane.ts
+
+diff --git a/scripts/control-plane-benchmark.ts b/scripts/control-plane-benchmark.ts
+new file mode 100644
+index 000000000..cffce8847
+--- /dev/null
++++ b/scripts/control-plane-benchmark.ts
+@@ -0,0 +1,98 @@
++import { performance } from "node:perf_hooks";
++import { dispatchReplyFromConfig } from "../src/auto-reply/reply/dispatch-from-config.js";
++import type { ReplyDispatcher } from "../src/auto-reply/reply/reply-dispatcher.js";
++import { buildTestCtx } from "../src/auto-reply/reply/test-ctx.js";
++import type { OpenClawConfig } from "../src/config/config.js";
++
++function percentile(values: number[], p: number): number {
++  if (values.length === 0) {
++    return 0;
++  }
++  const sorted = [...values].toSorted((a, b) => a - b);
++  const idx = Math.min(sorted.length - 1, Math.ceil((p / 100) * sorted.length) - 1);
++  return sorted[Math.max(0, idx)] ?? 0;
++}
++
++async function run() {
++  const cfg = {} as OpenClawConfig;
++  const ack: number[] = [];
++  const status: number[] = [];
++  const dispatch: number[] = [];
++
++  for (let round = 0; round < 5; round += 1) {
++    const jobs: Promise<void>[] = [];
++    for (let i = 0; i < 5; i += 1) {
++      jobs.push(
++        (async () => {
++          const t0 = performance.now();
++          const marks: number[] = [];
++          const dispatcher: ReplyDispatcher = {
++            sendToolResult: () => true,
++            sendBlockReply: () => true,
++            sendFinalReply: () => {
++              marks.push(performance.now());
++              return true;
++            },
++            waitForIdle: async () => {},
++            getQueuedCounts: () => ({ tool: 0, block: 0, final: marks.length }),
++            markComplete: () => {},
++          };
++          await dispatchReplyFromConfig({
++            ctx: buildTestCtx({ Body: "/stop", CommandBody: "/stop", CommandAuthorized: true }),
++            cfg,
++            dispatcher,
++          });
++          if (marks.length >= 1) {
++            ack.push(marks[0] - t0);
++          }
++          if (marks.length >= 2) {
++            dispatch.push(marks[1] - marks[0]);
++          }
++        })(),
++      );
++      jobs.push(
++        (async () => {
++          const t0 = performance.now();
++          const dispatcher: ReplyDispatcher = {
++            sendToolResult: () => true,
++            sendBlockReply: () => true,
++            sendFinalReply: () => true,
++            waitForIdle: async () => {},
++            getQueuedCounts: () => ({ tool: 0, block: 0, final: 1 }),
++            markComplete: () => {},
++          };
++          await dispatchReplyFromConfig({
++            ctx: buildTestCtx({ Body: "/status", CommandBody: "/status", CommandAuthorized: true }),
++            cfg,
++            dispatcher,
++          });
++          status.push(performance.now() - t0);
++        })(),
++      );
++    }
++    await Promise.all(jobs);
++  }
++
++  const ackP95 = percentile(ack, 95);
++  const statusP95 = percentile(status, 95);
++  const dispatchP95 = percentile(dispatch, 95);
++
++  console.log(
++    JSON.stringify(
++      {
++        rounds: 5,
++        samples: { ack: ack.length, status: status.length, dispatch: dispatch.length },
++        p95: { ackMs: ackP95, statusMs: statusP95, stopDispatchMs: dispatchP95 },
++        pass: {
++          ack: ackP95 < 200,
++          status: statusP95 < 500,
++          dispatch: dispatchP95 < 2000,
++        },
++      },
++      null,
++      2,
++    ),
++  );
++}
++
++void run();
+diff --git a/src/auto-reply/control-plane.test.ts b/src/auto-reply/control-plane.test.ts
+new file mode 100644
+index 000000000..a37010d67
+--- /dev/null
++++ b/src/auto-reply/control-plane.test.ts
+@@ -0,0 +1,124 @@
++import fs from "node:fs";
++import os from "node:os";
++import path from "node:path";
++import { beforeEach, describe, expect, it, vi } from "vitest";
++import type { OpenClawConfig } from "../config/config.js";
++import { maybeHandleControlPlaneCommand, matchStrictControlCommand } from "./control-plane.js";
++import type { ReplyDispatcher } from "./reply/reply-dispatcher.js";
++import { buildTestCtx } from "./reply/test-ctx.js";
++
++const abortMock = vi.hoisted(() =>
++  vi.fn(async () => ({ handled: true, aborted: true, stoppedSubagents: 0 })),
++);
++
++vi.mock("./reply/abort.js", async () => {
++  const actual = await vi.importActual<typeof import("./reply/abort.js")>("./reply/abort.js");
++  return {
++    ...actual,
++    tryFastAbortFromMessage: abortMock,
++  };
++});
++
++function createDispatcher(): ReplyDispatcher {
++  return {
++    sendToolResult: vi.fn(() => true),
++    sendBlockReply: vi.fn(() => true),
++    sendFinalReply: vi.fn(() => true),
++    waitForIdle: vi.fn(async () => {}),
++    getQueuedCounts: vi.fn(() => ({ tool: 0, block: 0, final: 0 })),
++    markComplete: vi.fn(),
++  };
++}
++
++describe("control plane strict matching", () => {
++  it("matches only full /stop or /status forms", () => {
++    expect(matchStrictControlCommand(" /stop ")?.command).toBe("stop");
++    expect(matchStrictControlCommand("/status@openclaw")?.command).toBe("status");
++    expect(matchStrictControlCommand("hello /stop")).toBeNull();
++    expect(matchStrictControlCommand("/status now")).toBeNull();
++    expect(matchStrictControlCommand("/stop\nnext")).toBeNull();
++  });
++});
++
++describe("maybeHandleControlPlaneCommand", () => {
++  const originalStateDir = process.env.OPENCLAW_STATE_DIR;
++  beforeEach(() => {
++    abortMock.mockClear();
++    process.env.OPENCLAW_STATE_DIR = originalStateDir;
++  });
++
++  it("handles /stop in control plane and sends ack before final", async () => {
++    const dispatcher = createDispatcher();
++    const ctx = buildTestCtx({
++      Body: "/stop",
++      CommandBody: "/stop",
++      CommandAuthorized: true,
++    });
++
++    const result = await maybeHandleControlPlaneCommand({
++      ctx,
++      cfg: {} as OpenClawConfig,
++      dispatcher,
++    });
++
++    expect(result.handled).toBe(true);
++    expect(abortMock).toHaveBeenCalledTimes(1);
++    const calls = (dispatcher.sendFinalReply as ReturnType<typeof vi.fn>).mock.calls;
++    expect(calls.length).toBeGreaterThanOrEqual(2);
++    expect(String(calls[0]?.[0]?.text ?? "")).toContain("Stopping...");
++  });
++
++  it("does not handle non-full matches", async () => {
++    const dispatcher = createDispatcher();
++    const ctx = buildTestCtx({
++      Body: "please /stop",
++      CommandBody: "please /stop",
++      CommandAuthorized: true,
++    });
++
++    const result = await maybeHandleControlPlaneCommand({
++      ctx,
++      cfg: {} as OpenClawConfig,
++      dispatcher,
++    });
++    expect(result.handled).toBe(false);
++    expect(abortMock).not.toHaveBeenCalled();
++  });
++
++  it("supports abortable control waits", async () => {
++    const dispatcher = createDispatcher();
++    const ctx = buildTestCtx({ Body: "/stop", CommandBody: "/stop", CommandAuthorized: true });
++    const ac = new AbortController();
++    ac.abort();
++
++    const result = await maybeHandleControlPlaneCommand({
++      ctx,
++      cfg: {} as OpenClawConfig,
++      dispatcher,
++      signal: ac.signal,
++    });
++
++    expect(result.handled).toBe(true);
++    const calls = (dispatcher.sendFinalReply as ReturnType<typeof vi.fn>).mock.calls;
++    expect(String(calls[calls.length - 1]?.[0]?.text ?? "")).toContain("aborted");
++  });
++
++  it("replays non-terminal commands into recovered terminal event", async () => {
++    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "oc-control-"));
++    process.env.OPENCLAW_STATE_DIR = stateDir;
++    const agentDir = path.join(stateDir, "agents", "main");
++    fs.mkdirSync(agentDir, { recursive: true });
++    fs.writeFileSync(
++      path.join(agentDir, "control-queue.jsonl"),
++      `${JSON.stringify({ commandId: "cmd_pending" })}\n`,
++      "utf8",
++    );
++
++    const dispatcher = createDispatcher();
++    const ctx = buildTestCtx({ Body: "/status", CommandBody: "/status", CommandAuthorized: true });
++    await maybeHandleControlPlaneCommand({ ctx, cfg: {} as OpenClawConfig, dispatcher });
++
++    const events = fs.readFileSync(path.join(agentDir, "control-events.jsonl"), "utf8");
++    expect(events).toContain("TIMED_OUT_RECOVERED");
++  });
++});
+diff --git a/src/auto-reply/control-plane.ts b/src/auto-reply/control-plane.ts
+new file mode 100644
+index 000000000..475864d6c
+--- /dev/null
++++ b/src/auto-reply/control-plane.ts
+@@ -0,0 +1,324 @@
++import crypto from "node:crypto";
++import fs from "node:fs";
++import path from "node:path";
++import { resolveSessionAgentId } from "../agents/agent-scope.js";
++import type { OpenClawConfig } from "../config/config.js";
++import { resolveStateDir } from "../config/paths.js";
++import { resolveCommandAuthorization } from "./command-auth.js";
++import { formatAbortReplyText, tryFastAbortFromMessage } from "./reply/abort.js";
++import type { ReplyDispatcher } from "./reply/reply-dispatcher.js";
++import type { FinalizedMsgContext } from "./templating.js";
++
++export const STRICT_CONTROL_COMMAND_RE = /^\/(stop|status)(?:@[\w_]+)?$/i;
++
++type ControlCommand = "stop" | "status";
++
++type ControlEnvelope = {
++  commandId: string;
++  seq: number;
++  agentId: string;
++  adapter: string;
++  chatId?: string;
++  senderId?: string;
++  sessionId?: string;
++  normalized: `/${ControlCommand}`;
++  raw: string;
++  ingressAt: string;
++  deadlineMs: number;
++};
++
++type ControlState = {
++  lastCommandId?: string;
++  lastCommand?: string;
++  status?: "queued" | "ack_sent" | "done" | "failed" | "timed_out";
++  updatedAt?: string;
++  lastResult?: string;
++};
++
++export function matchStrictControlCommand(
++  raw?: string,
++): { command: ControlCommand; rawTrimmed: string } | null {
++  const rawTrimmed = String(raw ?? "").trim();
++  if (!rawTrimmed) {
++    return null;
++  }
++  const m = rawTrimmed.match(STRICT_CONTROL_COMMAND_RE);
++  if (!m) {
++    return null;
++  }
++  const command = m[1]?.toLowerCase();
++  if (command !== "stop" && command !== "status") {
++    return null;
++  }
++  return { command, rawTrimmed };
++}
++
++function appendJsonl(filePath: string, record: unknown): void {
++  fs.mkdirSync(path.dirname(filePath), { recursive: true });
++  fs.appendFileSync(filePath, `${JSON.stringify(record)}\n`, "utf8");
++}
++
++class AdapterCommandLogWriter {
++  constructor(
++    private readonly adapter: string,
++    private readonly stateDir: string,
++  ) {}
++  write(record: unknown): void {
++    appendJsonl(path.join(this.stateDir, "adapters", this.adapter, "command-log.jsonl"), record);
++  }
++}
++
++class AgentControlIngressWriter {
++  constructor(
++    private readonly agentId: string,
++    private readonly stateDir: string,
++  ) {}
++  appendQueue(record: unknown): void {
++    appendJsonl(path.join(this.stateDir, "agents", this.agentId, "control-queue.jsonl"), record);
++  }
++}
++
++class AgentControlExecutorWriter {
++  constructor(
++    private readonly agentId: string,
++    private readonly stateDir: string,
++  ) {}
++  appendEvent(record: unknown): void {
++    appendJsonl(path.join(this.stateDir, "agents", this.agentId, "control-events.jsonl"), record);
++  }
++  writeState(state: ControlState): void {
++    const filePath = path.join(this.stateDir, "agents", this.agentId, "control-state.json");
++    fs.mkdirSync(path.dirname(filePath), { recursive: true });
++    fs.writeFileSync(filePath, JSON.stringify(state, null, 2), "utf8");
++  }
++  readState(): ControlState {
++    const filePath = path.join(this.stateDir, "agents", this.agentId, "control-state.json");
++    try {
++      return JSON.parse(fs.readFileSync(filePath, "utf8")) as ControlState;
++    } catch {
++      return {};
++    }
++  }
++}
++
++function shortCommandId(commandId: string): string {
++  return commandId.slice(-6);
++}
++
++let globalSeq = 0;
++
++async function withTimeout<T>(
++  promise: Promise<T>,
++  timeoutMs: number,
++  signal?: AbortSignal,
++): Promise<{ ok: true; value: T } | { ok: false; reason: "timeout" | "aborted" }> {
++  if (signal?.aborted) {
++    return { ok: false, reason: "aborted" };
++  }
++  return await new Promise((resolve) => {
++    const timer = setTimeout(
++      () => resolve({ ok: false as const, reason: "timeout" as const }),
++      timeoutMs,
++    );
++    const onAbort = () => {
++      clearTimeout(timer);
++      resolve({ ok: false as const, reason: "aborted" as const });
++    };
++    signal?.addEventListener("abort", onAbort, { once: true });
++    void promise
++      .then((value) => {
++        clearTimeout(timer);
++        signal?.removeEventListener("abort", onAbort);
++        resolve({ ok: true as const, value });
++      })
++      .catch(() => {
++        clearTimeout(timer);
++        signal?.removeEventListener("abort", onAbort);
++        resolve({ ok: false as const, reason: "timeout" as const });
++      });
++  });
++}
++
++function recoverNonTerminalCommands(agentId: string, stateDir: string): void {
++  const queueFile = path.join(stateDir, "agents", agentId, "control-queue.jsonl");
++  const eventsFile = path.join(stateDir, "agents", agentId, "control-events.jsonl");
++  if (!fs.existsSync(queueFile)) {
++    return;
++  }
++  const queueLines = fs
++    .readFileSync(queueFile, "utf8")
++    .split("\n")
++    .map((l) => l.trim())
++    .filter(Boolean)
++    .map((l) => JSON.parse(l) as { commandId?: string });
++  const terminal = new Set<string>();
++  if (fs.existsSync(eventsFile)) {
++    for (const line of fs.readFileSync(eventsFile, "utf8").split("\n")) {
++      const t = line.trim();
++      if (!t) {
++        continue;
++      }
++      const evt = JSON.parse(t) as { commandId?: string; type?: string };
++      if (
++        evt.commandId &&
++        ["DONE", "FAILED", "TIMED_OUT", "TIMED_OUT_RECOVERED"].includes(String(evt.type))
++      ) {
++        terminal.add(evt.commandId);
++      }
++    }
++  }
++  const execWriter = new AgentControlExecutorWriter(agentId, stateDir);
++  for (const item of queueLines) {
++    if (!item.commandId || terminal.has(item.commandId)) {
++      continue;
++    }
++    execWriter.appendEvent({
++      eventId: `evt_${crypto.randomUUID()}`,
++      commandId: item.commandId,
++      agentId,
++      type: "TIMED_OUT_RECOVERED",
++      at: new Date().toISOString(),
++      data: { reason: "startup_recovery" },
++    });
++  }
++}
++
++export async function maybeHandleControlPlaneCommand(params: {
++  ctx: FinalizedMsgContext;
++  cfg: OpenClawConfig;
++  dispatcher: ReplyDispatcher;
++  signal?: AbortSignal;
++}): Promise<{ handled: boolean }> {
++  const { ctx, cfg, dispatcher, signal } = params;
++  const matched = matchStrictControlCommand(ctx.CommandBody ?? ctx.RawBody ?? ctx.Body ?? "");
++  if (!matched) {
++    return { handled: false };
++  }
++
++  const auth = resolveCommandAuthorization({ ctx, cfg, commandAuthorized: ctx.CommandAuthorized });
++  if (!auth.isAuthorizedSender) {
++    return { handled: true };
++  }
++
++  const adapter = String(ctx.Surface ?? ctx.Provider ?? "unknown").toLowerCase();
++  const agentId = resolveSessionAgentId({ sessionKey: ctx.SessionKey ?? "", config: cfg });
++  const stateDir = resolveStateDir();
++  recoverNonTerminalCommands(agentId, stateDir);
++
++  const commandId = `cmd_${crypto.randomUUID()}`;
++  const seq = ++globalSeq;
++  const now = new Date().toISOString();
++  const envelope: ControlEnvelope = {
++    commandId,
++    seq,
++    agentId,
++    adapter,
++    chatId: ctx.To ?? ctx.From,
++    senderId: auth.senderId,
++    sessionId: ctx.SessionKey,
++    normalized: `/${matched.command}`,
++    raw: matched.rawTrimmed,
++    ingressAt: now,
++    deadlineMs: matched.command === "status" ? 1000 : 3000,
++  };
++
++  const adapterWriter = new AdapterCommandLogWriter(adapter, stateDir);
++  const ingressWriter = new AgentControlIngressWriter(agentId, stateDir);
++  const execWriter = new AgentControlExecutorWriter(agentId, stateDir);
++
++  adapterWriter.write({ type: "RECEIVED", at: now, commandId, raw: matched.rawTrimmed });
++
++  if (matched.command === "status") {
++    const statusResult = await withTimeout(Promise.resolve(execWriter.readState()), 1000, signal);
++    const text = statusResult.ok
++      ? `Status#${shortCommandId(commandId)}: ${statusResult.value.status ?? "idle"}`
++      : `Status#${shortCommandId(commandId)}: timeout`;
++    dispatcher.sendFinalReply({ text });
++    execWriter.appendEvent({
++      eventId: `evt_${crypto.randomUUID()}`,
++      commandId,
++      seq,
++      agentId,
++      type: "DONE",
++      at: new Date().toISOString(),
++      data: { fastPath: true, status: statusResult.ok ? "ok" : statusResult.reason },
++    });
++    return { handled: true };
++  }
++
++  ingressWriter.appendQueue(envelope);
++  execWriter.appendEvent({
++    eventId: `evt_${crypto.randomUUID()}`,
++    commandId,
++    seq,
++    agentId,
++    type: "ENQUEUED",
++    at: new Date().toISOString(),
++  });
++  execWriter.writeState({
++    lastCommandId: commandId,
++    lastCommand: matched.command,
++    status: "queued",
++    updatedAt: new Date().toISOString(),
++  });
++
++  const ack = await withTimeout(
++    Promise.resolve(
++      dispatcher.sendFinalReply({ text: `Stopping... [#${shortCommandId(commandId)}]` }),
++    ),
++    1000,
++    signal,
++  );
++  execWriter.appendEvent({
++    eventId: `evt_${crypto.randomUUID()}`,
++    commandId,
++    seq,
++    agentId,
++    type: "ACK_SENT",
++    at: new Date().toISOString(),
++    data: { ok: ack.ok },
++  });
++
++  const dispatch = await withTimeout(tryFastAbortFromMessage({ ctx, cfg }), 3000, signal);
++  if (!dispatch.ok) {
++    dispatcher.sendFinalReply({
++      text: `Stop failed [#${shortCommandId(commandId)}]: ${dispatch.reason}`,
++    });
++    execWriter.appendEvent({
++      eventId: `evt_${crypto.randomUUID()}`,
++      commandId,
++      seq,
++      agentId,
++      type: "TIMED_OUT",
++      at: new Date().toISOString(),
++      data: { phase: "dispatch", reason: dispatch.reason },
++    });
++    execWriter.writeState({
++      lastCommandId: commandId,
++      lastCommand: matched.command,
++      status: "timed_out",
++      updatedAt: new Date().toISOString(),
++      lastResult: dispatch.reason,
++    });
++    return { handled: true };
++  }
++
++  const finalText = formatAbortReplyText(dispatch.value.stoppedSubagents);
++  dispatcher.sendFinalReply({ text: `${finalText} [#${shortCommandId(commandId)}]` });
++  execWriter.appendEvent({
++    eventId: `evt_${crypto.randomUUID()}`,
++    commandId,
++    seq,
++    agentId,
++    type: "DONE",
++    at: new Date().toISOString(),
++  });
++  execWriter.writeState({
++    lastCommandId: commandId,
++    lastCommand: matched.command,
++    status: "done",
++    updatedAt: new Date().toISOString(),
++    lastResult: finalText,
++  });
++  return { handled: true };
++}
+diff --git a/src/auto-reply/reply/dispatch-from-config.test.ts b/src/auto-reply/reply/dispatch-from-config.test.ts
+index 8c2012872..8dd57ccdf 100644
+--- a/src/auto-reply/reply/dispatch-from-config.test.ts
++++ b/src/auto-reply/reply/dispatch-from-config.test.ts
+@@ -125,6 +125,25 @@ describe("dispatchReplyFromConfig", () => {
+     internalHookMocks.createInternalHookEvent.mockImplementation(createInternalHookEventPayload);
+     internalHookMocks.triggerInternalHook.mockClear();
+   });
++  it("routes /stop through control plane and does not call reply resolver", async () => {
++    setNoAbort();
++    const cfg = emptyConfig;
++    const dispatcher = createDispatcher();
++    const ctx = buildTestCtx({
++      Provider: "whatsapp",
++      Surface: "whatsapp",
++      Body: "/stop",
++      CommandBody: "/stop",
++      CommandAuthorized: true,
++    });
++    const replyResolver = vi.fn(async () => ({ text: "should-not-run" }));
++
++    await dispatchReplyFromConfig({ ctx, cfg, dispatcher, replyResolver });
++
++    expect(replyResolver).not.toHaveBeenCalled();
++    expect(dispatcher.sendFinalReply).toHaveBeenCalled();
++  });
++
+   it("does not route when Provider matches OriginatingChannel (even if Surface is missing)", async () => {
+     setNoAbort();
+     mocks.routeReply.mockClear();
+diff --git a/src/auto-reply/reply/dispatch-from-config.ts b/src/auto-reply/reply/dispatch-from-config.ts
+index 009fab046..b116c1c11 100644
+--- a/src/auto-reply/reply/dispatch-from-config.ts
++++ b/src/auto-reply/reply/dispatch-from-config.ts
+@@ -13,6 +13,7 @@ import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+ import { enqueueCommandInLane } from "../../process/command-queue.js";
+ import { CommandLane } from "../../process/lanes.js";
+ import { maybeApplyTtsToPayload, normalizeTtsAutoMode, resolveTtsConfig } from "../../tts/tts.js";
++import { maybeHandleControlPlaneCommand } from "../control-plane.js";
+ import { getReplyFromConfig } from "../reply.js";
+ import type { FinalizedMsgContext } from "../templating.js";
+ import type { GetReplyOptions, ReplyPayload } from "../types.js";
+@@ -205,6 +206,14 @@ export async function dispatchReplyFromConfig(params: {
+     return { queuedFinal: false, counts: dispatcher.getQueuedCounts() };
+   }
+ 
++  const controlHandled = await maybeHandleControlPlaneCommand({ ctx, cfg, dispatcher });
++  if (controlHandled.handled) {
++    const counts = dispatcher.getQueuedCounts();
++    recordProcessed("completed", { reason: "control_plane" });
++    markIdle("message_completed");
++    return { queuedFinal: counts.final > 0, counts };
++  }
++
+   const inboundAudio = isInboundAudioContext(ctx);
+   const sessionTtsAuto = resolveSessionTtsAuto(ctx, cfg);
+   const hookRunner = getGlobalHookRunner();

--- a/patches/45febecf2a2d-autocompat/0009-fix-control-plane-align-control-lane-status-timeout-.patch
+++ b/patches/45febecf2a2d-autocompat/0009-fix-control-plane-align-control-lane-status-timeout-.patch
@@ -1,0 +1,64 @@
+From 6ef8136fc2f3741c0ba967c0949c9f9572e85365 Mon Sep 17 00:00:00 2001
+From: dddabtc <zhaodali78@gmail.com>
+Date: Fri, 20 Feb 2026 17:22:09 -0400
+Subject: [PATCH 09/16] fix(control-plane): align control-lane status/timeout
+ semantics
+
+---
+ src/auto-reply/control-plane.test.ts         | 6 +++++-
+ src/auto-reply/control-plane.ts              | 3 ---
+ src/auto-reply/reply/dispatch-from-config.ts | 3 +--
+ 3 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/src/auto-reply/control-plane.test.ts b/src/auto-reply/control-plane.test.ts
+index a37010d67..0f4967554 100644
+--- a/src/auto-reply/control-plane.test.ts
++++ b/src/auto-reply/control-plane.test.ts
+@@ -44,7 +44,11 @@ describe("maybeHandleControlPlaneCommand", () => {
+   const originalStateDir = process.env.OPENCLAW_STATE_DIR;
+   beforeEach(() => {
+     abortMock.mockClear();
+-    process.env.OPENCLAW_STATE_DIR = originalStateDir;
++    if (typeof originalStateDir === "string") {
++      process.env.OPENCLAW_STATE_DIR = originalStateDir;
++    } else {
++      delete process.env.OPENCLAW_STATE_DIR;
++    }
+   });
+ 
+   it("handles /stop in control plane and sends ack before final", async () => {
+diff --git a/src/auto-reply/control-plane.ts b/src/auto-reply/control-plane.ts
+index 475864d6c..1026da30c 100644
+--- a/src/auto-reply/control-plane.ts
++++ b/src/auto-reply/control-plane.ts
+@@ -196,9 +196,6 @@ export async function maybeHandleControlPlaneCommand(params: {
+   }
+ 
+   const auth = resolveCommandAuthorization({ ctx, cfg, commandAuthorized: ctx.CommandAuthorized });
+-  if (!auth.isAuthorizedSender) {
+-    return { handled: true };
+-  }
+ 
+   const adapter = String(ctx.Surface ?? ctx.Provider ?? "unknown").toLowerCase();
+   const agentId = resolveSessionAgentId({ sessionKey: ctx.SessionKey ?? "", config: cfg });
+diff --git a/src/auto-reply/reply/dispatch-from-config.ts b/src/auto-reply/reply/dispatch-from-config.ts
+index b116c1c11..db8542f68 100644
+--- a/src/auto-reply/reply/dispatch-from-config.ts
++++ b/src/auto-reply/reply/dispatch-from-config.ts
+@@ -57,7 +57,6 @@ const isInboundAudioContext = (ctx: FinalizedMsgContext): boolean => {
+   return AUDIO_HEADER_RE.test(trimmed);
+ };
+ 
+-
+ const STRICT_CONTROL_COMMAND_RE = /^\s*\/(stop|status)(?:@[\w_]+)?\s*$/i;
+ const CONTROL_ACK_TIMEOUT_MS = 1_000;
+ const CONTROL_ABORT_DISPATCH_TIMEOUT_MS = 3_000;
+@@ -211,7 +210,7 @@ export async function dispatchReplyFromConfig(params: {
+     const counts = dispatcher.getQueuedCounts();
+     recordProcessed("completed", { reason: "control_plane" });
+     markIdle("message_completed");
+-    return { queuedFinal: counts.final > 0, counts };
++    return { queuedFinal: true, counts };
+   }
+ 
+   const inboundAudio = isInboundAudioContext(ctx);

--- a/patches/45febecf2a2d-autocompat/0010-bench-retest-control-plane-and-document-command-hand.patch
+++ b/patches/45febecf2a2d-autocompat/0010-bench-retest-control-plane-and-document-command-hand.patch
@@ -1,0 +1,433 @@
+From 4fc8487df28d176c5dd8cfdff85fca33fe7dfbbe Mon Sep 17 00:00:00 2001
+From: dddabtc <zhaodali78@gmail.com>
+Date: Fri, 20 Feb 2026 17:38:53 -0400
+Subject: [PATCH 10/16] bench: retest control-plane and document command
+ handling
+
+---
+ README.md                                     |  25 ++
+ .../plans/control-plane-command-handling.md   |  99 ++++++++
+ scripts/control-plane-benchmark.ts            | 217 +++++++++++++++---
+ 3 files changed, 309 insertions(+), 32 deletions(-)
+ create mode 100644 docs/experiments/plans/control-plane-command-handling.md
+
+diff --git a/README.md b/README.md
+index 72f362418..0416a7cf8 100644
+--- a/README.md
++++ b/README.md
+@@ -281,6 +281,31 @@ Send these in WhatsApp/Telegram/Slack/Google Chat/Microsoft Teams/WebChat (group
+ - `/restart` — restart the gateway (owner-only in groups)
+ - `/activation mention|always` — group activation toggle (groups only)
+ 
++### Control-plane command handling (`/stop`, `/status`)
++
++`/stop` and `/status` are handled as control-plane commands (not normal session/data-plane chat turns):
++
++- strict full-match routing: `^/(stop|status)(?:@[\w_]+)?$`
++- `/status` uses a fast path (state read + immediate reply)
++- `/stop` uses two-stage reply (fast ACK, then final abort result)
++- command lifecycle is persisted under `~/.openclaw/{adapters,agents}/...` for audit/recovery
++
++Quick benchmark (concurrent + mixed):
++
++```bash
++node --import tsx scripts/control-plane-benchmark.ts
++# optional: ROUNDS=12 node --import tsx scripts/control-plane-benchmark.ts
++```
++
++Targets:
++
++- `/stop` ACK p95 < 200ms
++- `/status` p95 < 500ms
++- `/stop` total dispatch p95 < 2000ms
++- no collective timeout explosion under burst rounds
++
++Design + test details: `docs/experiments/plans/control-plane-command-handling.md`
++
+ ## Apps (optional)
+ 
+ The Gateway alone delivers a great experience. All apps are optional and add extra features.
+diff --git a/docs/experiments/plans/control-plane-command-handling.md b/docs/experiments/plans/control-plane-command-handling.md
+new file mode 100644
+index 000000000..f46162ef6
+--- /dev/null
++++ b/docs/experiments/plans/control-plane-command-handling.md
+@@ -0,0 +1,99 @@
++# Control-plane command handling (`/stop`, `/status`)
++
++Status: implementation + pressure-test aligned (2026-02)
++
++## Why
++
++Under load, command UX must stay responsive even when normal session/data-plane work is busy.
++The command path now follows a control-plane-first design so `/stop` and `/status` do not queue behind LLM/tool work.
++
++## Design goals
++
++1. **Control/Data split**: command handling is not treated as normal chat business flow.
++2. **Agent-scoped execution**: command queue/events are bound to agent state, not per-session lane.
++3. **Adapter ingress isolation**: each adapter writes its own ingress command log file.
++4. **Fast ACK**: `/stop` immediately replies with an ACK before abort dispatch.
++5. **Durable tracing**: command lifecycle is persisted and replayable.
++6. **Deterministic recovery**: non-terminal historical commands are marked as recovered on startup/path entry.
++
++## Current flow (implemented)
++
++### Strict command matching
++
++Only full-match commands enter control plane:
++
++```regex
++^/(stop|status)(?:@[\w_]+)?$
++```
++
++No partial/contains matching.
++
++### `/status` (fast path)
++
++- Bypasses queue.
++- Reads control state quickly.
++- Replies directly with status summary (`Status#xxxxxx: ...`).
++
++### `/stop` (two-stage)
++
++1. Persist enqueue + state update.
++2. Send immediate ACK (`Stopping... [#xxxxxx]`).
++3. Dispatch fast abort.
++4. Send final result (`Stopped ... [#xxxxxx]` or timeout/failure reason).
++
++## Durable files / evidence points
++
++Under `~/.openclaw` (or `OPENCLAW_STATE_DIR`):
++
++```text
++adapters/<adapter>/command-log.jsonl
++agents/<agentId>/control-queue.jsonl
++agents/<agentId>/control-events.jsonl
++agents/<agentId>/control-state.json
++```
++
++Key event types to validate:
++
++- `ENQUEUED`
++- `ACK_SENT`
++- `DONE` / `FAILED` / `TIMED_OUT` / `TIMED_OUT_RECOVERED`
++
++## Performance targets (SLO)
++
++- `/stop` ACK p95 < **200ms**
++- `/status` p95 < **500ms**
++- `/stop` total dispatch p95 < **2000ms**
++- Burst test should show **no collective timeout explosion**
++
++## Pressure-test method
++
++Reference script:
++
++- `scripts/control-plane-benchmark.ts`
++
++Run:
++
++```bash
++node --import tsx scripts/control-plane-benchmark.ts
++# optional rounds override (minimum 10 enforced by script)
++ROUNDS=12 node --import tsx scripts/control-plane-benchmark.ts
++```
++
++Scenario (per round):
++
++- `/stop` x5 + `/status` x5
++- concurrent mixed workload
++- repeated for >= 10 rounds
++
++Output includes:
++
++- per-round mean/p95/max
++- overall mean/p95/max
++- timeout counters
++- collective-timeout-burst flag
++- control-plane evidence (file deltas + event type counts)
++
++## Notes
++
++- This benchmark targets command-path logic and control-plane durability/latency, not external IM network jitter.
++- If command-path instrumentation changes, update this doc and script together to keep acceptance criteria stable.
+diff --git a/scripts/control-plane-benchmark.ts b/scripts/control-plane-benchmark.ts
+index cffce8847..1c3118042 100644
+--- a/scripts/control-plane-benchmark.ts
++++ b/scripts/control-plane-benchmark.ts
+@@ -1,8 +1,22 @@
++import fs from "node:fs";
++import os from "node:os";
++import path from "node:path";
+ import { performance } from "node:perf_hooks";
+ import { dispatchReplyFromConfig } from "../src/auto-reply/reply/dispatch-from-config.js";
+ import type { ReplyDispatcher } from "../src/auto-reply/reply/reply-dispatcher.js";
+ import { buildTestCtx } from "../src/auto-reply/reply/test-ctx.js";
+ import type { OpenClawConfig } from "../src/config/config.js";
++import { resolveStateDir } from "../src/config/paths.js";
++
++type Sample = { ms: number; timedOut: boolean };
++
++type RoundStats = {
++  round: number;
++  stopAck: { meanMs: number; p95Ms: number; maxMs: number; timeouts: number; samples: number };
++  stopTotal: { meanMs: number; p95Ms: number; maxMs: number; timeouts: number; samples: number };
++  status: { meanMs: number; p95Ms: number; maxMs: number; timeouts: number; samples: number };
++  collectiveTimeoutBurst: boolean;
++};
+ 
+ function percentile(values: number[], p: number): number {
+   if (values.length === 0) {
+@@ -13,24 +27,93 @@ function percentile(values: number[], p: number): number {
+   return sorted[Math.max(0, idx)] ?? 0;
+ }
+ 
++function mean(values: number[]): number {
++  if (values.length === 0) {
++    return 0;
++  }
++  return values.reduce((acc, v) => acc + v, 0) / values.length;
++}
++
++function summarize(samples: Sample[]) {
++  const values = samples.map((s) => s.ms);
++  const timeouts = samples.filter((s) => s.timedOut).length;
++  return {
++    meanMs: mean(values),
++    p95Ms: percentile(values, 95),
++    maxMs: values.length > 0 ? Math.max(...values) : 0,
++    timeouts,
++    samples: samples.length,
++  };
++}
++
++function tailJsonl(filePath: string, fromLine: number): unknown[] {
++  if (!fs.existsSync(filePath)) {
++    return [];
++  }
++  const lines = fs
++    .readFileSync(filePath, "utf8")
++    .split("\n")
++    .filter((l) => l.trim().length > 0);
++  return lines.slice(fromLine).map((line) => {
++    try {
++      return JSON.parse(line);
++    } catch {
++      return { __raw: line };
++    }
++  });
++}
++
++function lineCount(filePath: string): number {
++  if (!fs.existsSync(filePath)) {
++    return 0;
++  }
++  return fs
++    .readFileSync(filePath, "utf8")
++    .split("\n")
++    .filter((l) => l.trim().length > 0).length;
++}
++
+ async function run() {
++  const rounds = Math.max(10, Number.parseInt(process.env.ROUNDS ?? "10", 10) || 10);
++  const stopPerRound = 5;
++  const statusPerRound = 5;
++
+   const cfg = {} as OpenClawConfig;
+-  const ack: number[] = [];
+-  const status: number[] = [];
+-  const dispatch: number[] = [];
++  const stopAck: Sample[] = [];
++  const stopTotal: Sample[] = [];
++  const status: Sample[] = [];
++  const perRound: RoundStats[] = [];
++
++  const stateDir = resolveStateDir();
++  const adapterLog = path.join(stateDir, "adapters", "whatsapp", "command-log.jsonl");
++  const queueLog = path.join(stateDir, "agents", "main", "control-queue.jsonl");
++  const eventsLog = path.join(stateDir, "agents", "main", "control-events.jsonl");
++  const stateFile = path.join(stateDir, "agents", "main", "control-state.json");
++
++  const adapterStart = lineCount(adapterLog);
++  const queueStart = lineCount(queueLog);
++  const eventsStart = lineCount(eventsLog);
+ 
+-  for (let round = 0; round < 5; round += 1) {
++  for (let round = 1; round <= rounds; round += 1) {
++    const roundStopAck: Sample[] = [];
++    const roundStopTotal: Sample[] = [];
++    const roundStatus: Sample[] = [];
+     const jobs: Promise<void>[] = [];
+-    for (let i = 0; i < 5; i += 1) {
++
++    for (let i = 0; i < stopPerRound; i += 1) {
+       jobs.push(
+         (async () => {
+           const t0 = performance.now();
+           const marks: number[] = [];
++          const finalTexts: string[] = [];
+           const dispatcher: ReplyDispatcher = {
+             sendToolResult: () => true,
+             sendBlockReply: () => true,
+-            sendFinalReply: () => {
++            sendFinalReply: (payload) => {
+               marks.push(performance.now());
++              if (typeof payload?.text === "string") {
++                finalTexts.push(payload.text);
++              }
+               return true;
+             },
+             waitForIdle: async () => {},
+@@ -42,21 +125,29 @@ async function run() {
+             cfg,
+             dispatcher,
+           });
+-          if (marks.length >= 1) {
+-            ack.push(marks[0] - t0);
+-          }
+-          if (marks.length >= 2) {
+-            dispatch.push(marks[1] - marks[0]);
++
++          if (marks.length > 0) {
++            roundStopAck.push({ ms: marks[0] - t0, timedOut: false });
+           }
++          const totalMs = performance.now() - t0;
++          const timedOut = finalTexts.some((t) => /timeout/i.test(t));
++          roundStopTotal.push({ ms: totalMs, timedOut });
+         })(),
+       );
++    }
++
++    for (let i = 0; i < statusPerRound; i += 1) {
+       jobs.push(
+         (async () => {
+           const t0 = performance.now();
++          let finalText = "";
+           const dispatcher: ReplyDispatcher = {
+             sendToolResult: () => true,
+             sendBlockReply: () => true,
+-            sendFinalReply: () => true,
++            sendFinalReply: (payload) => {
++              finalText = String(payload?.text ?? "");
++              return true;
++            },
+             waitForIdle: async () => {},
+             getQueuedCounts: () => ({ tool: 0, block: 0, final: 1 }),
+             markComplete: () => {},
+@@ -66,33 +157,95 @@ async function run() {
+             cfg,
+             dispatcher,
+           });
+-          status.push(performance.now() - t0);
++
++          roundStatus.push({ ms: performance.now() - t0, timedOut: /timeout/i.test(finalText) });
+         })(),
+       );
+     }
++
+     await Promise.all(jobs);
++
++    stopAck.push(...roundStopAck);
++    stopTotal.push(...roundStopTotal);
++    status.push(...roundStatus);
++
++    const s1 = summarize(roundStopAck);
++    const s2 = summarize(roundStopTotal);
++    const s3 = summarize(roundStatus);
++    const collectiveTimeoutBurst = s2.timeouts + s3.timeouts >= 5;
++
++    perRound.push({
++      round,
++      stopAck: s1,
++      stopTotal: s2,
++      status: s3,
++      collectiveTimeoutBurst,
++    });
+   }
+ 
+-  const ackP95 = percentile(ack, 95);
+-  const statusP95 = percentile(status, 95);
+-  const dispatchP95 = percentile(dispatch, 95);
+-
+-  console.log(
+-    JSON.stringify(
+-      {
+-        rounds: 5,
+-        samples: { ack: ack.length, status: status.length, dispatch: dispatch.length },
+-        p95: { ackMs: ackP95, statusMs: statusP95, stopDispatchMs: dispatchP95 },
+-        pass: {
+-          ack: ackP95 < 200,
+-          status: statusP95 < 500,
+-          dispatch: dispatchP95 < 2000,
+-        },
++  const adapterRecords = tailJsonl(adapterLog, adapterStart) as Array<Record<string, unknown>>;
++  const queueRecords = tailJsonl(queueLog, queueStart) as Array<Record<string, unknown>>;
++  const eventRecords = tailJsonl(eventsLog, eventsStart) as Array<Record<string, unknown>>;
++
++  const eventTypeCount = eventRecords.reduce<Record<string, number>>((acc, r) => {
++    const eventType = r.type;
++    const k = typeof eventType === "string" && eventType.trim().length > 0 ? eventType : "unknown";
++    acc[k] = (acc[k] ?? 0) + 1;
++    return acc;
++  }, {});
++
++  const adapterReceived = adapterRecords.filter((r) => r.type === "RECEIVED").length;
++  const queueStop = queueRecords.filter((r) => r.normalized === "/stop").length;
++  const doneEvents = (eventTypeCount.DONE ?? 0) > 0;
++  const ackEvents = (eventTypeCount.ACK_SENT ?? 0) > 0;
++
++  const overall = {
++    stopAck: summarize(stopAck),
++    stopTotal: summarize(stopTotal),
++    status: summarize(status),
++  };
++  const collectiveTimeoutBurst = perRound.some((r) => r.collectiveTimeoutBurst);
++
++  const slo = {
++    ackP95Lt200: overall.stopAck.p95Ms < 200,
++    statusP95Lt500: overall.status.p95Ms < 500,
++    stopTotalP95Lt2000: overall.stopTotal.p95Ms < 2000,
++  };
++
++  const result = {
++    rounds,
++    scenario: {
++      perRound: { stop: stopPerRound, status: statusPerRound, mode: "concurrent" },
++      rateLimitContext: "same adapter+agent path, write/read mixed",
++      stateDir,
++    },
++    perRound,
++    overall,
++    collectiveTimeoutBurst,
++    controlPlaneEvidence: {
++      files: { adapterLog, queueLog, eventsLog, stateFile },
++      deltas: {
++        adapterRecords: adapterRecords.length,
++        queueRecords: queueRecords.length,
++        eventRecords: eventRecords.length,
+       },
+-      null,
+-      2,
+-    ),
+-  );
++      checks: {
++        adapterReceived,
++        queueStop,
++        eventTypeCount,
++        hasAckSent: ackEvents,
++        hasDone: doneEvents,
++        stateFileExists: fs.existsSync(stateFile),
++      },
++      verified:
++        adapterReceived > 0 && queueStop > 0 && ackEvents && doneEvents && fs.existsSync(stateFile),
++    },
++    slo,
++    pass: Object.values(slo).every(Boolean) && !collectiveTimeoutBurst,
++    host: os.hostname(),
++  };
++
++  console.log(JSON.stringify(result, null, 2));
+ }
+ 
+ void run();

--- a/patches/45febecf2a2d-autocompat/0011-feat-control-unify-command-handling-and-add-real-tel.patch
+++ b/patches/45febecf2a2d-autocompat/0011-feat-control-unify-command-handling-and-add-real-tel.patch
@@ -1,0 +1,756 @@
+From cebdabb7de11333b6516f284188bdafe052acdc9 Mon Sep 17 00:00:00 2001
+From: zhaod <zhaod@local>
+Date: Fri, 20 Feb 2026 22:02:05 -0400
+Subject: [PATCH 11/16] feat(control): unify command handling and add real
+ telegram inbound test script/docs
+
+---
+ docs/debug/telegram-control-inbound-test.md   |  72 +++++++
+ scripts/test_telegram_control_inbound.py      | 133 +++++++++++++
+ src/auto-reply/control-plane.ts               | 184 ++++++++++++------
+ .../reply/dispatch-from-config.test.ts        |  19 +-
+ src/auto-reply/reply/dispatch-from-config.ts  | 152 +--------------
+ src/auto-reply/status.ts                      |  12 ++
+ 6 files changed, 355 insertions(+), 217 deletions(-)
+ create mode 100755 docs/debug/telegram-control-inbound-test.md
+ create mode 100755 scripts/test_telegram_control_inbound.py
+
+diff --git a/docs/debug/telegram-control-inbound-test.md b/docs/debug/telegram-control-inbound-test.md
+new file mode 100755
+index 000000000..3841eed24
+--- /dev/null
++++ b/docs/debug/telegram-control-inbound-test.md
+@@ -0,0 +1,72 @@
++# Telegram Control Inbound Test (Real User via Telethon)
++
++This document explains how to run a **real inbound** `/status` + `/stop` test against OpenClaw Telegram control handling.
++
++## Why this exists
++
++`bot -> bot` messaging is not reliable for Telegram command testing.
++Use a **user account session** (Telethon) to send commands to the OpenClaw bot.
++
++## Script location
++
++- `scripts/test_telegram_control_inbound.py`
++
++## Prerequisites
++
++1. Telegram `api_id` + `api_hash` from `https://my.telegram.org`
++2. Test user id added to allowlist:
++
++```bash
++openclaw config set channels.telegram.allowFrom '["<owner_id>","<test_user_id>"]'
++systemctl --user restart openclaw-gateway.service
++```
++
++## Run
++
++```bash
++cd ~/openclaw-src
++python3 -m venv .venv
++source .venv/bin/activate
++pip install telethon
++
++python3 scripts/test_telegram_control_inbound.py \
++  --api-id <API_ID> \
++  --api-hash <API_HASH> \
++  --target @<openclaw_bot_username> \
++  --messages "/status,/stop"
++```
++
++First run will prompt for phone/code/2FA and persist a local Telethon session file.
++
++## Expected output
++
++The script prints:
++
++1. `BEFORE` snapshot of control files
++2. Sent command logs (`[telethon] sent: ...`)
++3. `AFTER` snapshot
++4. `DELTA` counters
++5. Tail snippets for:
++   - `~/.openclaw/adapters/telegram/command-log.jsonl`
++   - `~/.openclaw/agents/main/control-queue.jsonl`
++   - `~/.openclaw/agents/main/control-events.jsonl`
++   - `~/.openclaw/agents/main/control-state.json`
++
++## Pass criteria
++
++For `/stop`:
++
++- command-log has new `/stop` entry
++- queue gets a new record
++- events include: `ENQUEUED -> ACK_SENT -> DONE`
++- control-state updates with latest command id
++
++For `/status`:
++
++- command-log has new `/status` entry
++- response behavior follows current configured routing (native/control-plane)
++
++## Notes
++
++- The script uses **real inbound path**, not synthetic local dispatch.
++- Rotate `api_hash` if leaked. Never commit secrets.
+diff --git a/scripts/test_telegram_control_inbound.py b/scripts/test_telegram_control_inbound.py
+new file mode 100755
+index 000000000..4a89f3c32
+--- /dev/null
++++ b/scripts/test_telegram_control_inbound.py
+@@ -0,0 +1,133 @@
++#!/usr/bin/env python3
++"""
++Real inbound control command smoke test via Telethon (user session, NOT bot token).
++
++Usage:
++  python scripts/test_telegram_control_inbound.py \
++    --api-id 123456 \
++    --api-hash abcdef... \
++    --target @your_openclaw_bot \
++    --state-dir ~/.openclaw
++
++Optional:
++  --messages "/status,/stop"
++  --pause 1.0
++  --session-file scripts/.telethon_openclaw_test
++
++What it does:
++1) Captures before-counts of control-plane files
++2) Sends commands to OpenClaw Telegram bot as a real user account
++3) Waits briefly and captures after-counts
++4) Prints deltas + tail snippets
++"""
++
++from __future__ import annotations
++
++import argparse
++import asyncio
++import json
++import os
++from pathlib import Path
++from typing import Dict, List
++
++from telethon import TelegramClient
++
++TRACK_FILES = [
++    "adapters/telegram/command-log.jsonl",
++    "agents/main/control-queue.jsonl",
++    "agents/main/control-events.jsonl",
++    "agents/main/control-state.json",
++]
++
++
++def file_info(path: Path) -> Dict[str, object]:
++    if not path.exists():
++        return {"exists": False, "lines": 0, "size": 0}
++    size = path.stat().st_size
++    if path.suffix == ".json" and path.name == "control-state.json":
++        return {"exists": True, "lines": 1, "size": size}
++    try:
++        with path.open("r", encoding="utf-8") as f:
++            lines = sum(1 for _ in f)
++    except Exception:
++        lines = 0
++    return {"exists": True, "lines": lines, "size": size}
++
++
++def snapshot(state_dir: Path) -> Dict[str, Dict[str, object]]:
++    return {rel: file_info(state_dir / rel) for rel in TRACK_FILES}
++
++
++def tail(path: Path, n: int = 8) -> List[str]:
++    if not path.exists():
++        return ["<missing>"]
++    try:
++        lines = path.read_text(encoding="utf-8", errors="ignore").splitlines()
++        return lines[-n:] if lines else ["<empty>"]
++    except Exception as e:
++        return [f"<read error: {e}>"]
++
++
++async def send_commands(api_id: int, api_hash: str, session_file: str, target: str, messages: List[str], pause: float) -> None:
++    client = TelegramClient(session_file, api_id, api_hash)
++    await client.start()  # first run will prompt for phone/code/2FA
++    me = await client.get_me()
++    print(f"[telethon] logged in as user_id={me.id}")
++    print(f"[telethon] planned messages: {messages!r}")
++    for m in messages:
++        text = m.strip()
++        if not text:
++            continue
++        await client.send_message(target, text)
++        print(f"[telethon] sent: {text!r}")
++        await asyncio.sleep(pause)
++    await client.disconnect()
++
++
++def print_delta(before: Dict[str, Dict[str, object]], after: Dict[str, Dict[str, object]]) -> None:
++    print("\n=== DELTA ===")
++    for rel in TRACK_FILES:
++        b = before[rel]
++        a = after[rel]
++        print(
++            f"{rel}: exists {b['exists']} -> {a['exists']}, "
++            f"lines {b['lines']} -> {a['lines']}, size {b['size']} -> {a['size']}"
++        )
++
++
++def main() -> None:
++    ap = argparse.ArgumentParser()
++    ap.add_argument("--api-id", type=int, required=True)
++    ap.add_argument("--api-hash", required=True)
++    ap.add_argument("--target", required=True, help="@bot_username or numeric peer id")
++    ap.add_argument("--state-dir", default="~/.openclaw")
++    ap.add_argument("--messages", default="/status,/stop")
++    ap.add_argument("--pause", type=float, default=1.0)
++    ap.add_argument("--settle", type=float, default=3.0, help="wait seconds after sending before sampling after-state")
++    ap.add_argument("--session-file", default="scripts/.telethon_openclaw_test")
++    args = ap.parse_args()
++
++    state_dir = Path(os.path.expanduser(args.state_dir)).resolve()
++    before = snapshot(state_dir)
++    print("=== BEFORE ===")
++    print(json.dumps(before, ensure_ascii=False, indent=2))
++
++    messages = [m.strip() for m in args.messages.split(",") if m.strip()]
++    asyncio.run(send_commands(args.api_id, args.api_hash, args.session_file, args.target, messages, args.pause))
++    asyncio.run(asyncio.sleep(args.settle))
++
++    after = snapshot(state_dir)
++    print("\n=== AFTER ===")
++    print(json.dumps(after, ensure_ascii=False, indent=2))
++    print_delta(before, after)
++
++    print("\n=== TAILS ===")
++    for rel in TRACK_FILES:
++        p = state_dir / rel
++        print(f"\n--- {rel} ---")
++        for line in tail(p, n=8):
++            print(line)
++
++
++if __name__ == "__main__":
++    main()
+diff --git a/src/auto-reply/control-plane.ts b/src/auto-reply/control-plane.ts
+index 1026da30c..0d849e800 100644
+--- a/src/auto-reply/control-plane.ts
++++ b/src/auto-reply/control-plane.ts
+@@ -5,6 +5,7 @@ import { resolveSessionAgentId } from "../agents/agent-scope.js";
+ import type { OpenClawConfig } from "../config/config.js";
+ import { resolveStateDir } from "../config/paths.js";
+ import { resolveCommandAuthorization } from "./command-auth.js";
++import { normalizeCommandBody } from "./commands-registry.js";
+ import { formatAbortReplyText, tryFastAbortFromMessage } from "./reply/abort.js";
+ import type { ReplyDispatcher } from "./reply/reply-dispatcher.js";
+ import type { FinalizedMsgContext } from "./templating.js";
+@@ -25,6 +26,17 @@ type ControlEnvelope = {
+   raw: string;
+   ingressAt: string;
+   deadlineMs: number;
++  context?: {
++    from?: string;
++    to?: string;
++    provider?: string;
++    surface?: string;
++    chatType?: string;
++    commandAuthorized?: boolean;
++    senderId?: string;
++    senderName?: string;
++    senderUsername?: string;
++  };
+ };
+ 
+ type ControlState = {
+@@ -42,15 +54,11 @@ export function matchStrictControlCommand(
+   if (!rawTrimmed) {
+     return null;
+   }
+-  const m = rawTrimmed.match(STRICT_CONTROL_COMMAND_RE);
+-  if (!m) {
+-    return null;
+-  }
+-  const command = m[1]?.toLowerCase();
+-  if (command !== "stop" && command !== "status") {
++  const normalized = normalizeCommandBody(rawTrimmed);
++  if (normalized !== "/stop" && normalized !== "/status") {
+     return null;
+   }
+-  return { command, rawTrimmed };
++  return { command: normalized.slice(1) as ControlCommand, rawTrimmed };
+ }
+ 
+ function appendJsonl(filePath: string, record: unknown): void {
+@@ -139,6 +147,92 @@ async function withTimeout<T>(
+   });
+ }
+ 
++const agentControlChains = new Map<string, Promise<void>>();
++function enqueueAgentControl<T>(agentId: string, run: () => Promise<T>): Promise<T> {
++  const previous = agentControlChains.get(agentId) ?? Promise.resolve();
++  const chained = previous.catch(() => {}).then(run);
++  agentControlChains.set(
++    agentId,
++    chained.then(
++      () => undefined,
++      () => undefined,
++    ),
++  );
++  return chained;
++}
++
++function buildReplayContext(envelope: ControlEnvelope): FinalizedMsgContext {
++  return {
++    SessionKey: envelope.sessionId,
++    CommandTargetSessionKey: envelope.sessionId,
++    Body: envelope.raw,
++    RawBody: envelope.raw,
++    CommandBody: envelope.raw,
++    Provider: envelope.context?.provider ?? envelope.adapter,
++    Surface: envelope.context?.surface ?? envelope.adapter,
++    From: envelope.context?.from ?? envelope.chatId,
++    To: envelope.context?.to ?? envelope.chatId,
++    ChatType: envelope.context?.chatType,
++    SenderId: envelope.context?.senderId ?? envelope.senderId,
++    SenderName: envelope.context?.senderName,
++    SenderUsername: envelope.context?.senderUsername,
++    CommandAuthorized: envelope.context?.commandAuthorized ?? true,
++  } as FinalizedMsgContext;
++}
++
++async function executeStopEnvelope(params: {
++  envelope: ControlEnvelope;
++  cfg: OpenClawConfig;
++  stateDir: string;
++  signal?: AbortSignal;
++}): Promise<{ ok: true; finalText: string } | { ok: false; reason: "timeout" | "aborted" }> {
++  const { envelope, cfg, stateDir, signal } = params;
++  const execWriter = new AgentControlExecutorWriter(envelope.agentId, stateDir);
++
++  const dispatch = await withTimeout(
++    tryFastAbortFromMessage({ ctx: buildReplayContext(envelope), cfg }),
++    3000,
++    signal,
++  );
++  if (!dispatch.ok) {
++    execWriter.appendEvent({
++      eventId: `evt_${crypto.randomUUID()}`,
++      commandId: envelope.commandId,
++      seq: envelope.seq,
++      agentId: envelope.agentId,
++      type: "TIMED_OUT",
++      at: new Date().toISOString(),
++      data: { phase: "dispatch", reason: dispatch.reason },
++    });
++    execWriter.writeState({
++      lastCommandId: envelope.commandId,
++      lastCommand: "stop",
++      status: "timed_out",
++      updatedAt: new Date().toISOString(),
++      lastResult: dispatch.reason,
++    });
++    return { ok: false, reason: dispatch.reason };
++  }
++
++  const finalText = formatAbortReplyText(dispatch.value.stoppedSubagents);
++  execWriter.appendEvent({
++    eventId: `evt_${crypto.randomUUID()}`,
++    commandId: envelope.commandId,
++    seq: envelope.seq,
++    agentId: envelope.agentId,
++    type: "DONE",
++    at: new Date().toISOString(),
++  });
++  execWriter.writeState({
++    lastCommandId: envelope.commandId,
++    lastCommand: "stop",
++    status: "done",
++    updatedAt: new Date().toISOString(),
++    lastResult: finalText,
++  });
++  return { ok: true, finalText };
++}
++
+ function recoverNonTerminalCommands(agentId: string, stateDir: string): void {
+   const queueFile = path.join(stateDir, "agents", agentId, "control-queue.jsonl");
+   const eventsFile = path.join(stateDir, "agents", agentId, "control-events.jsonl");
+@@ -217,6 +311,17 @@ export async function maybeHandleControlPlaneCommand(params: {
+     raw: matched.rawTrimmed,
+     ingressAt: now,
+     deadlineMs: matched.command === "status" ? 1000 : 3000,
++    context: {
++      from: ctx.From,
++      to: ctx.To,
++      provider: ctx.Provider,
++      surface: ctx.Surface,
++      chatType: ctx.ChatType,
++      commandAuthorized: ctx.CommandAuthorized,
++      senderId: ctx.SenderId,
++      senderName: ctx.SenderName,
++      senderUsername: ctx.SenderUsername,
++    },
+   };
+ 
+   const adapterWriter = new AdapterCommandLogWriter(adapter, stateDir);
+@@ -226,21 +331,7 @@ export async function maybeHandleControlPlaneCommand(params: {
+   adapterWriter.write({ type: "RECEIVED", at: now, commandId, raw: matched.rawTrimmed });
+ 
+   if (matched.command === "status") {
+-    const statusResult = await withTimeout(Promise.resolve(execWriter.readState()), 1000, signal);
+-    const text = statusResult.ok
+-      ? `Status#${shortCommandId(commandId)}: ${statusResult.value.status ?? "idle"}`
+-      : `Status#${shortCommandId(commandId)}: timeout`;
+-    dispatcher.sendFinalReply({ text });
+-    execWriter.appendEvent({
+-      eventId: `evt_${crypto.randomUUID()}`,
+-      commandId,
+-      seq,
+-      agentId,
+-      type: "DONE",
+-      at: new Date().toISOString(),
+-      data: { fastPath: true, status: statusResult.ok ? "ok" : statusResult.reason },
+-    });
+-    return { handled: true };
++    return { handled: false };
+   }
+ 
+   ingressWriter.appendQueue(envelope);
+@@ -275,47 +366,24 @@ export async function maybeHandleControlPlaneCommand(params: {
+     at: new Date().toISOString(),
+     data: { ok: ack.ok },
+   });
++  execWriter.writeState({
++    lastCommandId: commandId,
++    lastCommand: matched.command,
++    status: "ack_sent",
++    updatedAt: new Date().toISOString(),
++  });
+ 
+-  const dispatch = await withTimeout(tryFastAbortFromMessage({ ctx, cfg }), 3000, signal);
+-  if (!dispatch.ok) {
++  const executeResult = await enqueueAgentControl(agentId, async () =>
++    executeStopEnvelope({ envelope, cfg, stateDir, signal }),
++  );
++
++  if (!executeResult.ok) {
+     dispatcher.sendFinalReply({
+-      text: `Stop failed [#${shortCommandId(commandId)}]: ${dispatch.reason}`,
+-    });
+-    execWriter.appendEvent({
+-      eventId: `evt_${crypto.randomUUID()}`,
+-      commandId,
+-      seq,
+-      agentId,
+-      type: "TIMED_OUT",
+-      at: new Date().toISOString(),
+-      data: { phase: "dispatch", reason: dispatch.reason },
+-    });
+-    execWriter.writeState({
+-      lastCommandId: commandId,
+-      lastCommand: matched.command,
+-      status: "timed_out",
+-      updatedAt: new Date().toISOString(),
+-      lastResult: dispatch.reason,
++      text: `Stop failed [#${shortCommandId(commandId)}]: ${executeResult.reason}`,
+     });
+     return { handled: true };
+   }
+ 
+-  const finalText = formatAbortReplyText(dispatch.value.stoppedSubagents);
+-  dispatcher.sendFinalReply({ text: `${finalText} [#${shortCommandId(commandId)}]` });
+-  execWriter.appendEvent({
+-    eventId: `evt_${crypto.randomUUID()}`,
+-    commandId,
+-    seq,
+-    agentId,
+-    type: "DONE",
+-    at: new Date().toISOString(),
+-  });
+-  execWriter.writeState({
+-    lastCommandId: commandId,
+-    lastCommand: matched.command,
+-    status: "done",
+-    updatedAt: new Date().toISOString(),
+-    lastResult: finalText,
+-  });
++  dispatcher.sendFinalReply({ text: `${executeResult.finalText} [#${shortCommandId(commandId)}]` });
+   return { handled: true };
+ }
+diff --git a/src/auto-reply/reply/dispatch-from-config.test.ts b/src/auto-reply/reply/dispatch-from-config.test.ts
+index 8dd57ccdf..1ed22c73d 100644
+--- a/src/auto-reply/reply/dispatch-from-config.test.ts
++++ b/src/auto-reply/reply/dispatch-from-config.test.ts
+@@ -73,7 +73,8 @@ vi.mock("../../hooks/internal-hooks.js", () => ({
+   triggerInternalHook: internalHookMocks.triggerInternalHook,
+ }));
+ 
+-const { dispatchReplyFromConfig, matchStrictControlCommand } = await import("./dispatch-from-config.js");
++const { dispatchReplyFromConfig, matchStrictControlCommand } =
++  await import("./dispatch-from-config.js");
+ const { resetInboundDedupe } = await import("./inbound-dedupe.js");
+ 
+ const noAbortResult = { handled: false, aborted: false } as const;
+@@ -574,7 +575,7 @@ describe("dispatchReplyFromConfig", () => {
+     expect(matchStrictControlCommand("/stop please")).toBeNull();
+   });
+ 
+-  it("handles /status in control lane without invoking model resolver", async () => {
++  it("routes /status through regular command handling when control-plane fast path is disabled", async () => {
+     setNoAbort();
+     const dispatcher = createDispatcher();
+     const ctx = buildTestCtx({
+@@ -584,13 +585,16 @@ describe("dispatchReplyFromConfig", () => {
+       RawBody: "/status",
+       Body: "/status",
+     });
+-    const replyResolver = vi.fn(async () => {
+-      throw new Error("model unavailable");
+-    });
++    const replyResolver = vi.fn(async () => ({ text: "ok" }) as ReplyPayload);
+ 
+-    const result = await dispatchReplyFromConfig({ ctx, cfg: emptyConfig, dispatcher, replyResolver });
++    const result = await dispatchReplyFromConfig({
++      ctx,
++      cfg: emptyConfig,
++      dispatcher,
++      replyResolver,
++    });
+ 
+-    expect(replyResolver).not.toHaveBeenCalled();
++    expect(replyResolver).toHaveBeenCalled();
+     expect(dispatcher.sendFinalReply).toHaveBeenCalled();
+     expect(result.queuedFinal).toBe(true);
+   });
+@@ -615,5 +619,4 @@ describe("dispatchReplyFromConfig", () => {
+     expect(String(calls[0]?.[0]?.text ?? "")).toContain("Stopping");
+     expect(String(calls[calls.length - 1]?.[0]?.text ?? "")).toContain("timeout");
+   }, 10000);
+-
+ });
+diff --git a/src/auto-reply/reply/dispatch-from-config.ts b/src/auto-reply/reply/dispatch-from-config.ts
+index db8542f68..e21fbc0dd 100644
+--- a/src/auto-reply/reply/dispatch-from-config.ts
++++ b/src/auto-reply/reply/dispatch-from-config.ts
+@@ -3,15 +3,13 @@ import type { OpenClawConfig } from "../../config/config.js";
+ import { loadSessionStore, resolveStorePath } from "../../config/sessions.js";
+ import { logVerbose } from "../../globals.js";
+ import { createInternalHookEvent, triggerInternalHook } from "../../hooks/internal-hooks.js";
+-import { emitDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
++import { isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
+ import {
+   logMessageProcessed,
+   logMessageQueued,
+   logSessionStateChange,
+ } from "../../logging/diagnostic.js";
+ import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+-import { enqueueCommandInLane } from "../../process/command-queue.js";
+-import { CommandLane } from "../../process/lanes.js";
+ import { maybeApplyTtsToPayload, normalizeTtsAutoMode, resolveTtsConfig } from "../../tts/tts.js";
+ import { maybeHandleControlPlaneCommand } from "../control-plane.js";
+ import { getReplyFromConfig } from "../reply.js";
+@@ -58,8 +56,6 @@ const isInboundAudioContext = (ctx: FinalizedMsgContext): boolean => {
+ };
+ 
+ const STRICT_CONTROL_COMMAND_RE = /^\s*\/(stop|status)(?:@[\w_]+)?\s*$/i;
+-const CONTROL_ACK_TIMEOUT_MS = 1_000;
+-const CONTROL_ABORT_DISPATCH_TIMEOUT_MS = 3_000;
+ 
+ export function matchStrictControlCommand(text?: string): "stop" | "status" | null {
+   if (!text) {
+@@ -73,46 +69,6 @@ export function matchStrictControlCommand(text?: string): "stop" | "status" | nu
+   return command === "stop" || command === "status" ? command : null;
+ }
+ 
+-function createAbortError(): Error {
+-  const err = new Error("control command aborted");
+-  err.name = "AbortError";
+-  return err;
+-}
+-
+-async function runWithTimeout<T>(params: {
+-  timeoutMs: number;
+-  signal?: AbortSignal;
+-  run: (signal: AbortSignal) => Promise<T>;
+-}): Promise<T> {
+-  if (params.signal?.aborted) {
+-    throw createAbortError();
+-  }
+-  const controller = new AbortController();
+-  const onAbort = () => controller.abort();
+-  params.signal?.addEventListener("abort", onAbort, { once: true });
+-  const timeout = setTimeout(() => controller.abort(), params.timeoutMs);
+-  try {
+-    const runPromise = params.run(controller.signal);
+-    const abortPromise = new Promise<never>((_, reject) => {
+-      controller.signal.addEventListener(
+-        "abort",
+-        () => {
+-          if (params.signal?.aborted) {
+-            reject(createAbortError());
+-            return;
+-          }
+-          reject(new Error(`timeout ${params.timeoutMs}ms`));
+-        },
+-        { once: true },
+-      );
+-    });
+-    return await Promise.race([runPromise, abortPromise]);
+-  } finally {
+-    clearTimeout(timeout);
+-    params.signal?.removeEventListener("abort", onAbort);
+-  }
+-}
+-
+ const resolveSessionTtsAuto = (
+   ctx: FinalizedMsgContext,
+   cfg: OpenClawConfig,
+@@ -342,112 +298,6 @@ export async function dispatchReplyFromConfig(params: {
+     }
+   };
+ 
+-  const ingressBody = ctx.CommandBody ?? ctx.RawBody ?? ctx.Body;
+-  const strictControlCommand = matchStrictControlCommand(ingressBody);
+-  if (strictControlCommand) {
+-    emitDiagnosticEvent({
+-      type: "command_ingress",
+-      sessionKey: ctx.SessionKey,
+-      command: strictControlCommand,
+-    });
+-
+-    const controlResult = await enqueueCommandInLane(CommandLane.Control, async () => {
+-      emitDiagnosticEvent({
+-        type: "control_dequeue",
+-        sessionKey: ctx.SessionKey,
+-        command: strictControlCommand,
+-      });
+-
+-      const emitPayload = async (payload: ReplyPayload, signal?: AbortSignal): Promise<boolean> => {
+-        if (shouldRouteToOriginating && originatingChannel && originatingTo) {
+-          const result = await routeReply({
+-            payload,
+-            channel: originatingChannel,
+-            to: originatingTo,
+-            sessionKey: ctx.SessionKey,
+-            accountId: ctx.AccountId,
+-            threadId: ctx.MessageThreadId,
+-            cfg,
+-            abortSignal: signal,
+-          });
+-          return result.ok;
+-        }
+-        return dispatcher.sendFinalReply(payload);
+-      };
+-
+-      let queuedFinal = false;
+-      const counts = dispatcher.getQueuedCounts();
+-
+-      if (strictControlCommand === "stop") {
+-        const ackOk = await runWithTimeout({
+-          timeoutMs: CONTROL_ACK_TIMEOUT_MS,
+-          run: (signal) => emitPayload({ text: "Stopping..." }, signal),
+-        });
+-        if (ackOk) {
+-          counts.final += 1;
+-          emitDiagnosticEvent({
+-            type: "ack_sent",
+-            sessionKey: ctx.SessionKey,
+-            command: "stop",
+-          });
+-        }
+-
+-        try {
+-          const fastAbort = await runWithTimeout({
+-            timeoutMs: CONTROL_ABORT_DISPATCH_TIMEOUT_MS,
+-            run: () => tryFastAbortFromMessage({ ctx, cfg }),
+-          });
+-          emitDiagnosticEvent({
+-            type: "abort_dispatched",
+-            sessionKey: ctx.SessionKey,
+-            command: "stop",
+-            handled: fastAbort.handled,
+-          });
+-          const doneText = fastAbort.handled
+-            ? formatAbortReplyText(fastAbort.stoppedSubagents)
+-            : "⚠️ Stop request was not applied (not authorized or no active target).";
+-          queuedFinal = await emitPayload({ text: doneText });
+-          if (queuedFinal) {
+-            counts.final += 1;
+-          }
+-        } catch (err) {
+-          const reason = String(err);
+-          queuedFinal = await emitPayload({
+-            text: `⚠️ Stop failed: ${reason.includes("timeout") ? "abort dispatch timeout (3s)" : reason}`,
+-          });
+-          if (queuedFinal) {
+-            counts.final += 1;
+-          }
+-        }
+-
+-        return { queuedFinal, counts };
+-      }
+-
+-      const statusOk = await runWithTimeout({
+-        timeoutMs: CONTROL_ACK_TIMEOUT_MS,
+-        run: (signal) =>
+-          emitPayload(
+-            {
+-              text: "✅ Status: control plane is responsive.",
+-            },
+-            signal,
+-          ),
+-      });
+-      if (statusOk) {
+-        counts.final += 1;
+-        emitDiagnosticEvent({
+-          type: "status_replied",
+-          sessionKey: ctx.SessionKey,
+-          command: "status",
+-        });
+-      }
+-      return { queuedFinal: statusOk, counts };
+-    });
+-
+-    recordProcessed("completed", { reason: `control_${strictControlCommand}` });
+-    return controlResult;
+-  }
+-
+   markProcessing();
+ 
+   try {
+diff --git a/src/auto-reply/status.ts b/src/auto-reply/status.ts
+index 399997ea2..fde94242f 100644
+--- a/src/auto-reply/status.ts
++++ b/src/auto-reply/status.ts
+@@ -57,6 +57,16 @@ type AgentConfig = Partial<AgentDefaults> & {
+ 
+ export const formatTokenCount = formatTokenCountShared;
+ 
++function resolveDistPublishDateTime(): string {
++  try {
++    const stat = fs.statSync(new URL(import.meta.url));
++    const d = new Date(stat.mtimeMs);
++    return `${d.toISOString().slice(0, 19).replace("T", " ")}(UTC)`;
++  } catch {
++    return "unknown";
++  }
++}
++
+ type QueueStatus = {
+   mode?: string;
+   depth?: number;
+@@ -617,6 +627,7 @@ export function buildStatusMessage(args: StatusArgs): string {
+     : null;
+   const commit = resolveCommitHash();
+   const versionLine = `🦞 OpenClaw ${VERSION}${commit ? ` (${commit})` : ""}`;
++  const personalLine = `🏷️ PERSONAL BUILD · ${resolveDistPublishDateTime()}`;
+   const usagePair = formatUsagePair(inputTokens, outputTokens);
+   const cacheLine = formatCacheLine(inputTokens, cacheRead, cacheWrite);
+   const costLine = costLabel ? `💵 Cost: ${costLabel}` : null;
+@@ -627,6 +638,7 @@ export function buildStatusMessage(args: StatusArgs): string {
+ 
+   return [
+     versionLine,
++    personalLine,
+     args.timeLine,
+     modelLine,
+     fallbackLine,

--- a/patches/45febecf2a2d-autocompat/0012-fix-commands-decouple-telegram-command-lane-and-rest.patch
+++ b/patches/45febecf2a2d-autocompat/0012-fix-commands-decouple-telegram-command-lane-and-rest.patch
@@ -1,0 +1,348 @@
+From 56eb29de0096e5a30be4faef185c4caa5c763d88 Mon Sep 17 00:00:00 2001
+From: zhaod <zhaod@local>
+Date: Fri, 20 Feb 2026 23:32:31 -0400
+Subject: [PATCH 12/16] fix(commands): decouple telegram command lane and
+ restore fast status handling
+
+---
+ docs/debug/telegram-control-inbound-test.md  |  32 +++
+ scripts/test_telegram_subsession_pressure.py | 195 +++++++++++++++++++
+ src/agents/system-prompt.ts                  |   1 +
+ src/auto-reply/control-plane.ts              |  31 ++-
+ src/telegram/bot-native-commands.ts          |   6 +-
+ 5 files changed, 263 insertions(+), 2 deletions(-)
+ create mode 100755 scripts/test_telegram_subsession_pressure.py
+
+diff --git a/docs/debug/telegram-control-inbound-test.md b/docs/debug/telegram-control-inbound-test.md
+index 3841eed24..990347f94 100755
+--- a/docs/debug/telegram-control-inbound-test.md
++++ b/docs/debug/telegram-control-inbound-test.md
+@@ -70,3 +70,35 @@ For `/status`:
+ 
+ - The script uses **real inbound path**, not synthetic local dispatch.
+ - Rotate `api_hash` if leaked. Never commit secrets.
++
++## Command lane bypass (anti-blocking)
++
++Current behavior in `src/telegram/bot-native-commands.ts`:
++
++- Strict command-word messages matching `^/[A-Za-z0-9_]+(?:@[\w_]+)?$` are assigned
++  a separate session key: `telegram:commands:<senderId>`.
++- This decouples command handling from the normal chat lane and avoids long waits
++  when the main session is congested.
++
++## Sub-session routing pressure probe
++
++Additional script:
++
++- `scripts/test_telegram_subsession_pressure.py`
++
++Purpose:
++
++1. Send natural-language test prompts via Telethon
++2. Validate sample first (`INVALID_SAMPLE` vs tool-call detected)
++3. Determine route (`MAIN_SESSION` or `SUB_SESSION`)
++
++Example:
++
++```bash
++python3 scripts/test_telegram_subsession_pressure.py \
++  --api-id <API_ID> \
++  --api-hash <API_HASH> \
++  --target @<openclaw_bot_username> \
++  --messages "ssh 到192.168.1.136 用户名是 zhaod，执行 hostname 并把结果告诉我" \
++  --rounds 1 --pause 0.5 --settle 20
++```
+diff --git a/scripts/test_telegram_subsession_pressure.py b/scripts/test_telegram_subsession_pressure.py
+new file mode 100755
+index 000000000..ddae88f65
+--- /dev/null
++++ b/scripts/test_telegram_subsession_pressure.py
+@@ -0,0 +1,195 @@
++#!/usr/bin/env python3
++from __future__ import annotations
++
++import argparse
++import asyncio
++import json
++import os
++import time
++from pathlib import Path
++from typing import Any, Dict, List
++
++from telethon import TelegramClient
++
++
++TOOL_CALL_HINTS = [
++    '"recipient_name":"functions.',
++    '"tool_calls"',
++    '"function_call"',
++    '"tool_use"',
++    '"clientToolCall"',
++    '"sessions_spawn"',
++]
++
++
++def read_json(path: Path, default: Any) -> Any:
++    try:
++        return json.loads(path.read_text(encoding="utf-8"))
++    except Exception:
++        return default
++
++
++def line_count(path: Path) -> int:
++    if not path.exists():
++        return 0
++    with path.open("r", encoding="utf-8", errors="ignore") as f:
++        return sum(1 for _ in f)
++
++
++def get_main_session_id(state_dir: Path) -> str:
++    sessions_file = state_dir / "agents/main/sessions/sessions.json"
++    data = read_json(sessions_file, {})
++    if isinstance(data, dict):
++        entry = data.get("agent:main:main")
++        if isinstance(entry, dict):
++            sid = entry.get("sessionId")
++            if isinstance(sid, str) and sid:
++                return sid
++    return ""
++
++
++def read_new_lines(path: Path, from_line: int) -> List[str]:
++    if not path.exists():
++        return []
++    out: List[str] = []
++    with path.open("r", encoding="utf-8", errors="ignore") as f:
++        for idx, line in enumerate(f, start=1):
++            if idx > from_line:
++                out.append(line.rstrip("\n"))
++    return out
++
++
++def snapshot(state_dir: Path) -> Dict[str, Any]:
++    cmd_log = state_dir / "adapters/telegram/command-log.jsonl"
++    sessions_file = state_dir / "agents/main/sessions/sessions.json"
++
++    sessions = read_json(sessions_file, {})
++    keys: List[str] = []
++    if isinstance(sessions, dict):
++        if isinstance(sessions.get("sessions"), list):
++            entries = sessions.get("sessions", [])
++            keys = [e.get("key") for e in entries if isinstance(e, dict) and e.get("key")]
++        else:
++            keys = [k for k in sessions.keys() if isinstance(k, str)]
++    sub_keys = [k for k in keys if ":subagent:" in k]
++
++    sid = get_main_session_id(state_dir)
++    main_jsonl = state_dir / "agents/main/sessions" / f"{sid}.jsonl" if sid else None
++    main_lines = line_count(main_jsonl) if main_jsonl else 0
++
++    return {
++        "command_log_lines": line_count(cmd_log),
++        "sessions_total": len(keys),
++        "subsessions_total": len(sub_keys),
++        "subsession_keys": sub_keys,
++        "main_session_id": sid,
++        "main_session_jsonl": str(main_jsonl) if main_jsonl else "",
++        "main_session_lines": main_lines,
++    }
++
++
++async def send_messages(api_id: int, api_hash: str, session_file: str, target: str, messages: List[str], rounds: int, pause: float) -> None:
++    client = TelegramClient(session_file, api_id, api_hash)
++    await client.start()
++    me = await client.get_me()
++    print(f"[telethon] logged in as user_id={me.id}")
++    print(f"[telethon] planned messages={messages!r}, rounds={rounds}")
++    for r in range(rounds):
++        for m in messages:
++            text = m.strip()
++            if not text:
++                continue
++            await client.send_message(target, text)
++            print(f"[telethon] round={r+1} sent={text!r}")
++            await asyncio.sleep(pause)
++    await client.disconnect()
++
++
++def detect_tool_call(new_main_lines: List[str]) -> Dict[str, Any]:
++    joined = "\n".join(new_main_lines)
++    matched = [h for h in TOOL_CALL_HINTS if h in joined]
++    return {
++        "tool_call_detected": len(matched) > 0,
++        "matched_hints": matched,
++    }
++
++
++def determine_route(tool_call_detected: bool, new_subsessions: int, new_main_lines: List[str]) -> str:
++    joined = "\n".join(new_main_lines)
++    if not tool_call_detected:
++        return "INVALID_SAMPLE"
++    if new_subsessions > 0 or '"sessions_spawn"' in joined or ':subagent:' in joined:
++        return "SUB_SESSION"
++    return "MAIN_SESSION"
++
++
++def print_summary(before: Dict[str, Any], after: Dict[str, Any], elapsed: float, new_main_lines: List[str]) -> None:
++    before_set = set(before.get("subsession_keys", []))
++    after_set = set(after.get("subsession_keys", []))
++    new_sub = sorted(after_set - before_set)
++
++    tool = detect_tool_call(new_main_lines)
++    route = determine_route(tool["tool_call_detected"], len(new_sub), new_main_lines)
++
++    print("\n=== SUMMARY ===")
++    print(f"elapsed_sec={elapsed:.2f}")
++    print(f"command_log_lines: {before['command_log_lines']} -> {after['command_log_lines']} (+{after['command_log_lines']-before['command_log_lines']})")
++    print(f"sessions_total: {before['sessions_total']} -> {after['sessions_total']} (+{after['sessions_total']-before['sessions_total']})")
++    print(f"subsessions_total: {before['subsessions_total']} -> {after['subsessions_total']} (+{after['subsessions_total']-before['subsessions_total']})")
++    print(f"new_subsessions={len(new_sub)}")
++    for k in new_sub[:20]:
++        print(f"  - {k}")
++
++    print("\n=== PHASE-1 (sample validity) ===")
++    print(f"tool_call_detected={tool['tool_call_detected']}")
++    print(f"matched_hints={tool['matched_hints']}")
++
++    print("\n=== PHASE-2 (routing) ===")
++    print(f"route={route}")
++
++    print("\n=== MAIN SESSION NEW LINES (tail 8) ===")
++    for line in new_main_lines[-8:]:
++        print(line[:500])
++
++
++
++def main() -> None:
++    ap = argparse.ArgumentParser()
++    ap.add_argument("--api-id", type=int, required=True)
++    ap.add_argument("--api-hash", required=True)
++    ap.add_argument("--target", required=True)
++    ap.add_argument("--messages", required=True)
++    ap.add_argument("--rounds", type=int, default=1)
++    ap.add_argument("--pause", type=float, default=0.5)
++    ap.add_argument("--settle", type=float, default=10.0)
++    ap.add_argument("--state-dir", default="~/.openclaw")
++    ap.add_argument("--session-file", default="scripts/.telethon_openclaw_test")
++    args = ap.parse_args()
++
++    state_dir = Path(os.path.expanduser(args.state_dir)).resolve()
++    messages = [m.strip() for m in args.messages.split(",") if m.strip()]
++    if not messages:
++        raise SystemExit("No valid messages in --messages")
++
++    before = snapshot(state_dir)
++    print("=== BEFORE ===")
++    print(json.dumps(before, ensure_ascii=False, indent=2))
++
++    started = time.time()
++    asyncio.run(send_messages(args.api_id, args.api_hash, args.session_file, args.target, messages, args.rounds, args.pause))
++    asyncio.run(asyncio.sleep(args.settle))
++    elapsed = time.time() - started
++
++    after = snapshot(state_dir)
++    print("\n=== AFTER ===")
++    print(json.dumps(after, ensure_ascii=False, indent=2))
++
++    new_main_lines: List[str] = []
++    if before.get("main_session_jsonl"):
++        new_main_lines = read_new_lines(Path(before["main_session_jsonl"]), int(before.get("main_session_lines", 0)))
++
++    print_summary(before, after, elapsed, new_main_lines)
++
++
++if __name__ == "__main__":
++    main()
+diff --git a/src/agents/system-prompt.ts b/src/agents/system-prompt.ts
+index 74530db68..d3b44c476 100644
+--- a/src/agents/system-prompt.ts
++++ b/src/agents/system-prompt.ts
+@@ -456,6 +456,7 @@ export function buildAgentSystemPrompt(params: {
+     "TOOLS.md does not control tool availability; it is user guidance for how to use external tools.",
+     `For long waits, avoid rapid poll loops: use ${execToolName} with enough yieldMs or ${processToolName}(action=poll, timeout=<ms>).`,
+     "If a task is more complex or takes longer, spawn a sub-agent. Completion is push-based: it will auto-announce when done.",
++    "Default rule: if work needs any tool call, do it in a sub-agent via sessions_spawn; only run tool calls in the main session when the user explicitly forces main-session execution.",
+     "Do not poll `subagents list` / `sessions_list` in a loop; only check status on-demand (for intervention, debugging, or when explicitly asked).",
+     "",
+     "## Tool Call Style",
+diff --git a/src/auto-reply/control-plane.ts b/src/auto-reply/control-plane.ts
+index 0d849e800..76b99566e 100644
+--- a/src/auto-reply/control-plane.ts
++++ b/src/auto-reply/control-plane.ts
+@@ -8,6 +8,7 @@ import { resolveCommandAuthorization } from "./command-auth.js";
+ import { normalizeCommandBody } from "./commands-registry.js";
+ import { formatAbortReplyText, tryFastAbortFromMessage } from "./reply/abort.js";
+ import type { ReplyDispatcher } from "./reply/reply-dispatcher.js";
++import { buildStatusMessage } from "./status.js";
+ import type { FinalizedMsgContext } from "./templating.js";
+ 
+ export const STRICT_CONTROL_COMMAND_RE = /^\/(stop|status)(?:@[\w_]+)?$/i;
+@@ -331,7 +332,35 @@ export async function maybeHandleControlPlaneCommand(params: {
+   adapterWriter.write({ type: "RECEIVED", at: now, commandId, raw: matched.rawTrimmed });
+ 
+   if (matched.command === "status") {
+-    return { handled: false };
++    const statusText = buildStatusMessage({
++      config: cfg,
++      agent: {
++        model: {
++          primary: cfg.agents?.defaults?.model?.primary ?? "unknown/unknown",
++        },
++        contextTokens: cfg.agents?.defaults?.contextTokens,
++      } as never,
++      agentId,
++      sessionKey: ctx.SessionKey,
++      resolvedVerbose: "off",
++      resolvedReasoning: "off",
++      queue: {
++        mode: "collect",
++        depth: 0,
++      },
++      includeTranscriptUsage: false,
++    });
++    dispatcher.sendFinalReply({ text: statusText });
++    execWriter.appendEvent({
++      eventId: `evt_${crypto.randomUUID()}`,
++      commandId,
++      seq,
++      agentId,
++      type: "DONE",
++      at: new Date().toISOString(),
++      data: { fastPath: true, status: "ok" },
++    });
++    return { handled: true };
+   }
+ 
+   ingressWriter.appendQueue(envelope);
+diff --git a/src/telegram/bot-native-commands.ts b/src/telegram/bot-native-commands.ts
+index adf413fbf..8241e2e97 100644
+--- a/src/telegram/bot-native-commands.ts
++++ b/src/telegram/bot-native-commands.ts
+@@ -68,6 +68,7 @@ import { resolveTelegramGroupPromptSettings } from "./group-config-helpers.js";
+ import { buildInlineKeyboard } from "./send.js";
+ 
+ const EMPTY_RESPONSE_FALLBACK = "No response generated. Please try again.";
++const STRICT_COMMAND_WORD_RE = /^\/[A-Za-z0-9_]+(?:@[\w_]+)?$/i;
+ 
+ type TelegramNativeCommandContext = Context & { match?: string };
+ 
+@@ -557,6 +558,9 @@ export const registerTelegramNativeCommands = ({
+             groupConfig,
+             topicConfig,
+           });
++          const strictCommandWord = STRICT_COMMAND_WORD_RE.test((prompt ?? "").trim());
++          const commandLaneSessionKey = `telegram:commands:${senderId || chatId}`;
++          const effectiveSessionKey = strictCommandWord ? commandLaneSessionKey : sessionKey;
+           const conversationLabel = isGroup
+             ? msg.chat.title
+               ? `${msg.chat.title} id:${chatId}`
+@@ -584,7 +588,7 @@ export const registerTelegramNativeCommands = ({
+             WasMentioned: true,
+             CommandAuthorized: commandAuthorized,
+             CommandSource: "native" as const,
+-            SessionKey: `telegram:slash:${senderId || chatId}`,
++            SessionKey: effectiveSessionKey,
+             AccountId: route.accountId,
+             CommandTargetSessionKey: sessionKey,
+             MessageThreadId: threadSpec.id,

--- a/patches/45febecf2a2d-autocompat/0013-chore-status-add-byline-under-PERSONAL-BUILD-banner-.patch
+++ b/patches/45febecf2a2d-autocompat/0013-chore-status-add-byline-under-PERSONAL-BUILD-banner-.patch
@@ -1,0 +1,49 @@
+From 123afbd46dc7d63d29ab63cfb988e5ca4a2fabc7 Mon Sep 17 00:00:00 2001
+From: zhaod <zhaod@local>
+Date: Fri, 20 Feb 2026 23:49:29 -0400
+Subject: [PATCH 13/16] chore(status): add byline under PERSONAL BUILD banner
+ and document format
+
+---
+ docs/debug/telegram-control-inbound-test.md | 10 ++++++++++
+ src/auto-reply/status.ts                    |  2 ++
+ 2 files changed, 12 insertions(+)
+
+diff --git a/docs/debug/telegram-control-inbound-test.md b/docs/debug/telegram-control-inbound-test.md
+index 990347f94..61ad92486 100755
+--- a/docs/debug/telegram-control-inbound-test.md
++++ b/docs/debug/telegram-control-inbound-test.md
+@@ -102,3 +102,13 @@ python3 scripts/test_telegram_subsession_pressure.py \
+   --messages "ssh 到192.168.1.136 用户名是 zhaod，执行 hostname 并把结果告诉我" \
+   --rounds 1 --pause 0.5 --settle 20
+ ```
++
++## Status banner format (current)
++
++The `/status` output includes a custom banner block:
++
++1. `🦞 OpenClaw <version> (<commit>)`
++2. `🏷️ PERSONAL BUILD · <dist-publish-time>(UTC)`
++3. `by: https://github.com/dddabtc`
++
++This is rendered in the fast status path currently used on 113.
+diff --git a/src/auto-reply/status.ts b/src/auto-reply/status.ts
+index fde94242f..9d2885d65 100644
+--- a/src/auto-reply/status.ts
++++ b/src/auto-reply/status.ts
+@@ -628,6 +628,7 @@ export function buildStatusMessage(args: StatusArgs): string {
+   const commit = resolveCommitHash();
+   const versionLine = `🦞 OpenClaw ${VERSION}${commit ? ` (${commit})` : ""}`;
+   const personalLine = `🏷️ PERSONAL BUILD · ${resolveDistPublishDateTime()}`;
++  const byLine = `by: https://github.com/dddabtc`;
+   const usagePair = formatUsagePair(inputTokens, outputTokens);
+   const cacheLine = formatCacheLine(inputTokens, cacheRead, cacheWrite);
+   const costLine = costLabel ? `💵 Cost: ${costLabel}` : null;
+@@ -639,6 +640,7 @@ export function buildStatusMessage(args: StatusArgs): string {
+   return [
+     versionLine,
+     personalLine,
++    byLine,
+     args.timeLine,
+     modelLine,
+     fallbackLine,

--- a/patches/45febecf2a2d-autocompat/0014-fix-exec-hard-block-ssh-and-long-exec-in-main-sessio.patch
+++ b/patches/45febecf2a2d-autocompat/0014-fix-exec-hard-block-ssh-and-long-exec-in-main-sessio.patch
@@ -1,0 +1,76 @@
+From e7684a286fc13254b89eaa1129f2e5dd1fec14fc Mon Sep 17 00:00:00 2001
+From: dddabtc <zhaodali78@gmail.com>
+Date: Sun, 22 Feb 2026 14:23:17 -0400
+Subject: [PATCH 14/16] fix(exec): hard-block ssh and long exec in main session
+ policy
+
+---
+ ...ash-tools.exec.main-session-policy.test.ts | 17 +++++++++++++++++
+ src/agents/bash-tools.exec.ts                 | 19 ++++++++++++++++---
+ 2 files changed, 33 insertions(+), 3 deletions(-)
+
+diff --git a/src/agents/bash-tools.exec.main-session-policy.test.ts b/src/agents/bash-tools.exec.main-session-policy.test.ts
+index 567311829..7c6618c67 100644
+--- a/src/agents/bash-tools.exec.main-session-policy.test.ts
++++ b/src/agents/bash-tools.exec.main-session-policy.test.ts
+@@ -35,4 +35,21 @@ describe("exec main-session long-run guard", () => {
+       }),
+     ).rejects.toThrow("Main session policy blocked exec");
+   });
++
++  it("rejects ssh-style exec in main session", async () => {
++    const tool = createExecTool({
++      sessionKey: "agent:alpha:main",
++      mainSessionPolicy: {
++        forbidLongExec: true,
++        maxExecTimeoutSec: 120,
++      },
++    });
++
++    await expect(
++      tool.execute("call-deny-ssh", {
++        command: "ssh user@example.com hostname",
++        timeout: 30,
++      }),
++    ).rejects.toThrow("Main session policy blocked exec");
++  });
+ });
+diff --git a/src/agents/bash-tools.exec.ts b/src/agents/bash-tools.exec.ts
+index 06201a2e7..b19621094 100644
+--- a/src/agents/bash-tools.exec.ts
++++ b/src/agents/bash-tools.exec.ts
+@@ -163,6 +163,15 @@ function resolveMainSessionMaxExecTimeoutSec(policy?: ExecMainSessionPolicy) {
+   return Math.floor(raw);
+ }
+ 
++function isSshLikeExecCommand(command: string): boolean {
++  const trimmed = command.trim();
++  if (!trimmed) {
++    return false;
++  }
++  // Keep this strict to reduce false positives: block direct SSH-family invocations.
++  return /^(?:ssh|scp|sftp)\b/i.test(trimmed);
++}
++
+ export function createExecTool(
+   defaults?: ExecToolDefaults,
+   // oxlint-disable-next-line typescript/no-explicit-any
+@@ -252,11 +261,15 @@ export function createExecTool(
+         const longExecByForeground =
+           !backgroundRequestedByPolicy &&
+           (mainSessionPolicy.requireBackgroundForExec || yieldExceedsLimit);
+-        if (longExecByTimeout || longExecByForeground) {
++        const sshLikeCommand = isSshLikeExecCommand(params.command);
++        if (longExecByTimeout || longExecByForeground || sshLikeCommand) {
++          const reason = sshLikeCommand
++            ? "this command invokes SSH-family tooling (ssh/scp/sftp)"
++            : `this command is considered long-running (timeout must be <= ${maxExecTimeoutSec}s and long runs must use background mode)`;
+           throw new Error(
+             [
+-              `Main session policy blocked exec: this command is considered long-running (timeout must be <= ${maxExecTimeoutSec}s and long runs must use background mode).`,
+-              "Use sessions_spawn for longer tasks, or rerun exec with background=true / an appropriate yieldMs and timeout.",
++              `Main session policy blocked exec: ${reason}.`,
++              "Use sessions_spawn to run this in a sub-session, or rerun exec with background=true plus an appropriate yieldMs/timeout when policy allows.",
+             ].join("\n"),
+           );
+         }

--- a/patches/45febecf2a2d-autocompat/0015-fix-status-resolve-target-session-context-in-control.patch
+++ b/patches/45febecf2a2d-autocompat/0015-fix-status-resolve-target-session-context-in-control.patch
@@ -1,0 +1,94 @@
+From 1dd917cfcd37e49bb527a96451f2b4f5e7f763b6 Mon Sep 17 00:00:00 2001
+From: zhaod <zhaod@local>
+Date: Sun, 22 Feb 2026 19:43:26 -0400
+Subject: [PATCH 15/16] fix(status): resolve target session context in
+ control-plane fast path
+
+The /status command routed through the control-plane fast path was
+showing 0/200k context because it used the command-lane session
+(which has no conversation history) instead of the target chat session.
+
+Now loads the target session entry via CommandTargetSessionKey, resolving
+accurate context usage, compaction count, model overrides, and queue depth.
+---
+ src/auto-reply/control-plane.ts | 46 ++++++++++++++++++++++++++++-----
+ 1 file changed, 40 insertions(+), 6 deletions(-)
+
+diff --git a/src/auto-reply/control-plane.ts b/src/auto-reply/control-plane.ts
+index 76b99566e..3abf9848d 100644
+--- a/src/auto-reply/control-plane.ts
++++ b/src/auto-reply/control-plane.ts
+@@ -2,11 +2,16 @@ import crypto from "node:crypto";
+ import fs from "node:fs";
+ import path from "node:path";
+ import { resolveSessionAgentId } from "../agents/agent-scope.js";
++import { lookupContextTokens } from "../agents/context.js";
++import { DEFAULT_CONTEXT_TOKENS } from "../agents/defaults.js";
+ import type { OpenClawConfig } from "../config/config.js";
+ import { resolveStateDir } from "../config/paths.js";
++import { resolveStorePath } from "../config/sessions/paths.js";
++import { loadSessionStore } from "../config/sessions/store.js";
+ import { resolveCommandAuthorization } from "./command-auth.js";
+ import { normalizeCommandBody } from "./commands-registry.js";
+ import { formatAbortReplyText, tryFastAbortFromMessage } from "./reply/abort.js";
++import { getFollowupQueueDepth, resolveQueueSettings } from "./reply/queue.js";
+ import type { ReplyDispatcher } from "./reply/reply-dispatcher.js";
+ import { buildStatusMessage } from "./status.js";
+ import type { FinalizedMsgContext } from "./templating.js";
+@@ -332,21 +337,50 @@ export async function maybeHandleControlPlaneCommand(params: {
+   adapterWriter.write({ type: "RECEIVED", at: now, commandId, raw: matched.rawTrimmed });
+ 
+   if (matched.command === "status") {
++    // Resolve the *target* session (the main chat session) rather than the
++    // command-lane session so that context/compaction/usage stats are accurate.
++    const targetSessionKey = ctx.CommandTargetSessionKey?.trim() || ctx.SessionKey;
++    const targetAgentId = targetSessionKey
++      ? resolveSessionAgentId({ sessionKey: targetSessionKey, config: cfg })
++      : agentId;
++    const storePath = resolveStorePath(cfg.session?.store, { agentId: targetAgentId });
++    const sessionStore = loadSessionStore(storePath, { skipCache: true });
++    const targetEntry = targetSessionKey ? sessionStore[targetSessionKey] : undefined;
++
++    const agentDefaults = cfg.agents?.defaults ?? {};
++    const selectedModel =
++      targetEntry?.modelOverride ?? agentDefaults.model?.primary ?? "unknown/unknown";
++    const contextTokens =
++      targetEntry?.contextTokens ??
++      agentDefaults.contextTokens ??
++      lookupContextTokens(selectedModel) ??
++      DEFAULT_CONTEXT_TOKENS;
++
++    const queueSettings = resolveQueueSettings({
++      cfg,
++      channel: String(ctx.Surface ?? ctx.Provider ?? "unknown"),
++      sessionEntry: targetEntry,
++    });
++    const queueDepth = targetSessionKey ? getFollowupQueueDepth(targetSessionKey) : 0;
++
+     const statusText = buildStatusMessage({
+       config: cfg,
+       agent: {
++        ...agentDefaults,
+         model: {
+-          primary: cfg.agents?.defaults?.model?.primary ?? "unknown/unknown",
++          ...agentDefaults.model,
++          primary: selectedModel,
+         },
+-        contextTokens: cfg.agents?.defaults?.contextTokens,
++        contextTokens,
+       } as never,
+-      agentId,
+-      sessionKey: ctx.SessionKey,
++      agentId: targetAgentId,
++      sessionEntry: targetEntry,
++      sessionKey: targetSessionKey,
+       resolvedVerbose: "off",
+       resolvedReasoning: "off",
+       queue: {
+-        mode: "collect",
+-        depth: 0,
++        mode: queueSettings.mode ?? "collect",
++        depth: queueDepth,
+       },
+       includeTranscriptUsage: false,
+     });

--- a/patches/45febecf2a2d-autocompat/0016-fix-control-keep-strict-status-mention-match-and-dis.patch
+++ b/patches/45febecf2a2d-autocompat/0016-fix-control-keep-strict-status-mention-match-and-dis.patch
@@ -1,0 +1,107 @@
+From 94f8faaf52d5fff1a21e7b4a4c2765f95e1fdbb7 Mon Sep 17 00:00:00 2001
+From: dddabtc <zhaodali78@gmail.com>
+Date: Sun, 22 Feb 2026 23:21:52 -0400
+Subject: [PATCH 16/16] fix(control): keep strict /status mention match and
+ disable non-telegram status fast path
+
+---
+ src/auto-reply/control-plane.ts | 70 ++++-----------------------------
+ 1 file changed, 8 insertions(+), 62 deletions(-)
+
+diff --git a/src/auto-reply/control-plane.ts b/src/auto-reply/control-plane.ts
+index 3abf9848d..6cc275dec 100644
+--- a/src/auto-reply/control-plane.ts
++++ b/src/auto-reply/control-plane.ts
+@@ -13,7 +13,6 @@ import { normalizeCommandBody } from "./commands-registry.js";
+ import { formatAbortReplyText, tryFastAbortFromMessage } from "./reply/abort.js";
+ import { getFollowupQueueDepth, resolveQueueSettings } from "./reply/queue.js";
+ import type { ReplyDispatcher } from "./reply/reply-dispatcher.js";
+-import { buildStatusMessage } from "./status.js";
+ import type { FinalizedMsgContext } from "./templating.js";
+ 
+ export const STRICT_CONTROL_COMMAND_RE = /^\/(stop|status)(?:@[\w_]+)?$/i;
+@@ -60,11 +59,15 @@ export function matchStrictControlCommand(
+   if (!rawTrimmed) {
+     return null;
+   }
+-  const normalized = normalizeCommandBody(rawTrimmed);
+-  if (normalized !== "/stop" && normalized !== "/status") {
++  const m = rawTrimmed.match(STRICT_CONTROL_COMMAND_RE);
++  if (!m) {
+     return null;
+   }
+-  return { command: normalized.slice(1) as ControlCommand, rawTrimmed };
++  const command = (m[1] ?? "").toLowerCase();
++  if (command !== "stop" && command !== "status") {
++    return null;
++  }
++  return { command: command as ControlCommand, rawTrimmed };
+ }
+ 
+ function appendJsonl(filePath: string, record: unknown): void {
+@@ -337,64 +340,7 @@ export async function maybeHandleControlPlaneCommand(params: {
+   adapterWriter.write({ type: "RECEIVED", at: now, commandId, raw: matched.rawTrimmed });
+ 
+   if (matched.command === "status") {
+-    // Resolve the *target* session (the main chat session) rather than the
+-    // command-lane session so that context/compaction/usage stats are accurate.
+-    const targetSessionKey = ctx.CommandTargetSessionKey?.trim() || ctx.SessionKey;
+-    const targetAgentId = targetSessionKey
+-      ? resolveSessionAgentId({ sessionKey: targetSessionKey, config: cfg })
+-      : agentId;
+-    const storePath = resolveStorePath(cfg.session?.store, { agentId: targetAgentId });
+-    const sessionStore = loadSessionStore(storePath, { skipCache: true });
+-    const targetEntry = targetSessionKey ? sessionStore[targetSessionKey] : undefined;
+-
+-    const agentDefaults = cfg.agents?.defaults ?? {};
+-    const selectedModel =
+-      targetEntry?.modelOverride ?? agentDefaults.model?.primary ?? "unknown/unknown";
+-    const contextTokens =
+-      targetEntry?.contextTokens ??
+-      agentDefaults.contextTokens ??
+-      lookupContextTokens(selectedModel) ??
+-      DEFAULT_CONTEXT_TOKENS;
+-
+-    const queueSettings = resolveQueueSettings({
+-      cfg,
+-      channel: String(ctx.Surface ?? ctx.Provider ?? "unknown"),
+-      sessionEntry: targetEntry,
+-    });
+-    const queueDepth = targetSessionKey ? getFollowupQueueDepth(targetSessionKey) : 0;
+-
+-    const statusText = buildStatusMessage({
+-      config: cfg,
+-      agent: {
+-        ...agentDefaults,
+-        model: {
+-          ...agentDefaults.model,
+-          primary: selectedModel,
+-        },
+-        contextTokens,
+-      } as never,
+-      agentId: targetAgentId,
+-      sessionEntry: targetEntry,
+-      sessionKey: targetSessionKey,
+-      resolvedVerbose: "off",
+-      resolvedReasoning: "off",
+-      queue: {
+-        mode: queueSettings.mode ?? "collect",
+-        depth: queueDepth,
+-      },
+-      includeTranscriptUsage: false,
+-    });
+-    dispatcher.sendFinalReply({ text: statusText });
+-    execWriter.appendEvent({
+-      eventId: `evt_${crypto.randomUUID()}`,
+-      commandId,
+-      seq,
+-      agentId,
+-      type: "DONE",
+-      at: new Date().toISOString(),
+-      data: { fastPath: true, status: "ok" },
+-    });
+-    return { handled: true };
++    return { handled: false };
+   }
+ 
+   ingressWriter.appendQueue(envelope);


### PR DESCRIPTION
## Summary\n- reproduce issue #18 auto-compat failure locally in isolated temp clone\n- rebase overlay patch series onto upstream commit `45febecf2a2d91fd1a378bb2cae38ec21e71857e`\n- add new clean-applying patchset `patches/45febecf2a2d-autocompat` and compatibility entry\n\n## Root cause\nauto-compat copied an older patchset that no longer applied cleanly to v2026.2.22-2 (first patch conflict in `docs/tools/exec.md`, plus schema/telegram drift).\n\n## Validation\n- `scripts/validate-compatibility.py compatibility.json`\n- `OVERLAY_CI_ONLY_APPLY=1 ./scripts/apply-personal-patch.sh ./work-validate` on upstream 45febec (clean apply, all 16 patches)\n- `tests/openclaw-personal.test.sh`\n- upstream smoke path: install deps + `pnpm -s build` after patch apply on 45febec\n\nFixes #18