### PR TITLE
ci: 重构 auto-compat 硬路径 + 失败遗留 autofix 全流程

### DIFF
--- a/.github/auto-compat-state.json
+++ b/.github/auto-compat-state.json
@@ -1,0 +1,5 @@
+{
+  "failed": false,
+  "updatedAt": "1970-01-01T00:00:00Z",
+  "source": {}
+}

--- a/.github/workflows/auto-compat.yml
+++ b/.github/workflows/auto-compat.yml
@@ -4,9 +4,6 @@ name: auto-compat
   workflow_dispatch: {}
   schedule:
     - cron: '30 */6 * * *'
-  push:
-    paths:
-      - '.github/workflows/auto-compat.yml'
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
@@ -14,6 +11,7 @@ name: auto-compat
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.ref }}
@@ -27,6 +25,7 @@ jobs:
       latest_tag: ${{ steps.discover.outputs.latest_tag }}
       latest_sha: ${{ steps.discover.outputs.latest_sha }}
       already_supported: ${{ steps.check.outputs.already_supported }}
+      has_failure_residue: ${{ steps.state.outputs.has_failure_residue }}
     steps:
       - uses: actions/checkout@v4
 
@@ -34,9 +33,6 @@ jobs:
         id: discover
         run: |
           set -euo pipefail
-
-          # Use npm latest as canonical runtime version (e.g. 2026.2.21-2),
-          # and map it to a git commit via npm gitHead when available.
           NPM_META=$(curl -fsSL https://registry.npmjs.org/openclaw/latest)
           NPM_VERSION=$(echo "$NPM_META" | jq -r '.version // empty')
           NPM_GIT_HEAD=$(echo "$NPM_META" | jq -r '.gitHead // empty')
@@ -65,8 +61,14 @@ jobs:
 
           echo "latest_tag=v${NPM_VERSION}" >> "$GITHUB_OUTPUT"
           echo "latest_sha=$SHA" >> "$GITHUB_OUTPUT"
-          echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
-          echo "Discovered npm latest v${NPM_VERSION} @ $SHA (release tag: $RELEASE_TAG)"
+
+      - name: Read failure residue state
+        id: state
+        run: |
+          set -euo pipefail
+          residue=$(jq -r '.failed // false' .github/auto-compat-state.json)
+          echo "has_failure_residue=$residue" >> "$GITHUB_OUTPUT"
+          echo "failure residue: $residue"
 
       - name: Check if already supported in compatibility.json
         id: check
@@ -85,7 +87,7 @@ jobs:
   validate-and-pr:
     runs-on: ubuntu-latest
     needs: discover
-    if: github.event_name != 'pull_request' && needs.discover.outputs.already_supported != 'true'
+    if: github.event_name != 'pull_request' && needs.discover.outputs.already_supported != 'true' && needs.discover.outputs.has_failure_residue != 'true'
     env:
       UPSTREAM_TAG: ${{ needs.discover.outputs.latest_tag }}
       UPSTREAM_SHA: ${{ needs.discover.outputs.latest_sha }}
@@ -174,35 +176,28 @@ jobs:
           git -C ./work config user.name "github-actions[bot]"
           git -C ./work config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-      - name: Apply overlay patch set (candidate)
-        id: apply_patch
-        continue-on-error: true
+      - name: Apply overlay patch set (hard fail)
         run: |
           set -euo pipefail
           OVERLAY_CI_ONLY_APPLY=1 ./scripts/apply-personal-patch.sh ./work
 
       - name: Install dependencies for upstream workspace
-        if: steps.apply_patch.outcome == 'success'
         run: |
           cd work
           pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Run overlay build smoke (required)
-        if: steps.apply_patch.outcome == 'success'
-        id: smoke
         run: |
           cd work
           pnpm -s build
 
       - name: Build dist overlay artifact
-        if: steps.apply_patch.outcome == 'success'
         run: |
           scripts/build-dist-overlay.sh ./work dist-overlay
           mkdir -p out
           mv dist-overlay dist-overlay.tar.gz dist-overlay.tar.gz.sha256 out/
 
       - name: Fill overlayHeadCommit in compatibility.json
-        if: steps.apply_patch.outcome == 'success'
         run: |
           set -euo pipefail
           head_sha=$(git -C work rev-parse HEAD)
@@ -212,28 +207,42 @@ jobs:
           jq --arg version "$version" --arg sha "$sha" --arg head "$head_sha" '(.supported // []) |= map(if .openclawVersion == $version and .commitSha == $sha then .overlayHeadCommit = $head else . end)' compatibility.json > "$tmp"
           mv "$tmp" compatibility.json
 
+      - name: Update changelog for new support version
+        run: |
+          set -euo pipefail
+          version="${UPSTREAM_VERSION#v}"
+          today=$(date -u +%Y-%m-%d)
+          tmp=$(mktemp)
+          {
+            sed -n '1,6p' CHANGELOG.md
+            echo "## [overlay-v${version}] — ${today}"
+            echo
+            echo "### CI/CD"
+            echo "- \`ci(auto-compat)\`: auto-compat validated and added support for v${version}"
+            echo
+            echo "### Chores"
+            echo "- \`chore(compat)\`: add candidate support for v${version}"
+            echo
+            echo "---"
+            echo
+            sed -n '7,9999p' CHANGELOG.md
+          } > "$tmp"
+          mv "$tmp" CHANGELOG.md
+
       - name: Upload candidate artifacts
-        if: steps.apply_patch.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
           name: auto-compat-artifacts-${{ env.UPSTREAM_VERSION }}
           path: out/*
 
       - name: Cleanup workspace before PR commit
-        run: |
-          rm -rf work out
-
-      - name: Skip incompatible candidate patchset without failing workflow
-        if: steps.apply_patch.outcome != 'success'
-        run: |
-          echo "::warning::auto-compat skipped for ${UPSTREAM_VERSION}: candidate patchset ${AUTO_PATCHSET_DIR} did not apply cleanly to ${UPSTREAM_SHA}."
+        run: rm -rf work out
 
       - name: Create pull request for new compatibility support
-        if: steps.apply_patch.outcome == 'success'
         id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
-          commit-message: "chore(compat): add candidate support for ${{ env.UPSTREAM_VERSION }}"
+          commit-message: "chore(compat): add support candidate for ${{ env.UPSTREAM_VERSION }}"
           branch: "auto/compat-${{ env.UPSTREAM_VERSION }}"
           delete-branch: true
           title: "chore(compat): add support candidate for ${{ env.UPSTREAM_VERSION }}"
@@ -243,27 +252,92 @@ jobs:
             - Upstream version: `${{ env.UPSTREAM_VERSION }}`
             - Upstream commit: `${{ env.UPSTREAM_SHA }}`
             - Patch set dir: `${{ env.AUTO_PATCHSET_DIR }}`
-            - Smoke result: `${{ steps.smoke.outcome }}`
-
-            Notes:
-            - Patch apply + build + smoke are all required (all-green policy).
-            - PR will be auto-merged when checks are green.
+            - Hard policy: no skip; any failed step fails workflow.
           add-paths: |
             compatibility.json
+            CHANGELOG.md
             patches/**
           labels: |
             automation
             compatibility
 
-      - name: Enable auto-merge for compatibility PR (best-effort)
-        if: steps.apply_patch.outcome == 'success' && steps.cpr.outputs.pull-request-number != '' && steps.smoke.outcome == 'success'
-        continue-on-error: true
+      - name: Enable auto-merge for compatibility PR
+        if: steps.cpr.outputs.pull-request-number != ''
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           pr='${{ steps.cpr.outputs.pull-request-number }}'
           gh pr merge "$pr" --repo "$GITHUB_REPOSITORY" --auto --squash --delete-branch
+
+  mark-failure-residue:
+    if: github.event_name != 'pull_request' && failure() && needs.discover.outputs.already_supported != 'true'
+    needs: [discover, validate-and-pr]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Mark failure residue state
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          jq --arg ts "$ts" \
+            --arg workflow "$GITHUB_WORKFLOW" \
+            --arg run_id "$GITHUB_RUN_ID" \
+            '.failed=true | .updatedAt=$ts | .source={workflow:$workflow, runId:$run_id}' \
+            .github/auto-compat-state.json > /tmp/state.json
+          mv /tmp/state.json .github/auto-compat-state.json
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .github/auto-compat-state.json
+          if ! git diff --cached --quiet; then
+            git commit -m "ci(auto-compat): mark failure residue"
+            git push origin HEAD:main
+          fi
+
+  trigger-autofix:
+    if: github.event_name != 'pull_request' && (needs.discover.outputs.has_failure_residue == 'true' || needs.mark-failure-residue.result == 'success')
+    needs: [discover, mark-failure-residue]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger autofix workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          reason="previous-failure-residue"
+          if [[ "${{ needs.mark-failure-residue.result }}" == "success" ]]; then
+            reason="current-run-failure"
+          fi
+          gh workflow run autofix-on-failure.yml --repo "$GITHUB_REPOSITORY" \
+            -f source_reason="$reason" \
+            -f source_workflow="auto-compat" \
+            -f source_run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            -f source_branch="main"
+
+  clear-failure-residue:
+    if: github.event_name != 'pull_request' && success() && needs.discover.outputs.already_supported != 'true' && needs.discover.outputs.has_failure_residue != 'true'
+    needs: [discover, validate-and-pr]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Clear failure residue state
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          jq --arg ts "$ts" '.failed=false | .updatedAt=$ts | .source={}' .github/auto-compat-state.json > /tmp/state.json
+          mv /tmp/state.json .github/auto-compat-state.json
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .github/auto-compat-state.json
+          if ! git diff --cached --quiet; then
+            git commit -m "ci(auto-compat): clear failure residue"
+            git push origin HEAD:main
+          fi
+
   pr-verify:
     if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'auto/compat-')
     runs-on: ubuntu-latest

--- a/.github/workflows/autofix-on-failure.yml
+++ b/.github/workflows/autofix-on-failure.yml
@@ -8,7 +8,24 @@ name: autofix-on-failure
       - support-release-rollover
     types:
       - completed
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      source_reason:
+        description: "autofix trigger reason"
+        required: false
+        type: string
+      source_workflow:
+        description: "source workflow name"
+        required: false
+        type: string
+      source_run_url:
+        description: "source run url"
+        required: false
+        type: string
+      source_branch:
+        description: "source branch"
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -18,7 +35,7 @@ permissions:
 
 jobs:
   dispatch-copilot-fix:
-    if: github.event.workflow_run.conclusion == 'failure'
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'failure'
     runs-on: ubuntu-latest
     steps:
       - name: Gather failed run context
@@ -28,20 +45,33 @@ jobs:
         run: |
           set -euo pipefail
           REPO='${{ github.repository }}'
-          RUN_ID='${{ github.event.workflow_run.id }}'
-          RUN_URL='${{ github.event.workflow_run.html_url }}'
-          WORKFLOW='${{ github.event.workflow_run.name }}'
-          BRANCH='${{ github.event.workflow_run.head_branch }}'
-          DISPLAY_TITLE='${{ github.event.workflow_run.display_title }}'
+
+          if [[ '${{ github.event_name }}' == 'workflow_dispatch' ]]; then
+            RUN_ID='manual-dispatch'
+            RUN_URL='${{ inputs.source_run_url }}'
+            WORKFLOW='${{ inputs.source_workflow }}'
+            BRANCH='${{ inputs.source_branch }}'
+            DISPLAY_TITLE='${{ inputs.source_reason }}'
+            FAILED_JOBS='(triggered by residue/failure)'
+          else
+            RUN_ID='${{ github.event.workflow_run.id }}'
+            RUN_URL='${{ github.event.workflow_run.html_url }}'
+            WORKFLOW='${{ github.event.workflow_run.name }}'
+            BRANCH='${{ github.event.workflow_run.head_branch }}'
+            DISPLAY_TITLE='${{ github.event.workflow_run.display_title }}'
+            FAILED_JOBS=$(gh api repos/$REPO/actions/runs/$RUN_ID/jobs --jq '.jobs[] | select(.conclusion=="failure") | .name' | paste -sd ', ' -)
+            if [[ -z "${FAILED_JOBS:-}" ]]; then
+              FAILED_JOBS="(no failed job name available)"
+            fi
+          fi
+
+          if [[ -z "${WORKFLOW:-}" ]]; then WORKFLOW="unknown-workflow"; fi
+          if [[ -z "${BRANCH:-}" ]]; then BRANCH="main"; fi
+          if [[ -z "${RUN_URL:-}" ]]; then RUN_URL="n/a"; fi
 
           UPSTREAM_VERSION=$(printf '%s\n' "$DISPLAY_TITLE" | sed -nE 's/.*upstream[^0-9]*([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' | head -n1)
           if [[ -z "${UPSTREAM_VERSION:-}" ]]; then
             UPSTREAM_VERSION="n/a"
-          fi
-
-          FAILED_JOBS=$(gh api repos/$REPO/actions/runs/$RUN_ID/jobs --jq '.jobs[] | select(.conclusion=="failure") | .name' | paste -sd ', ' -)
-          if [[ -z "${FAILED_JOBS:-}" ]]; then
-            FAILED_JOBS="(no failed job name available)"
           fi
 
           DEDUPE_KEY="${WORKFLOW}|${BRANCH}|${UPSTREAM_VERSION}"

--- a/.github/workflows/autofix-pr-automerge.yml
+++ b/.github/workflows/autofix-pr-automerge.yml
@@ -45,6 +45,8 @@ jobs:
             exit 0
           fi
 
+          gh pr comment "$PR" --repo "$REPO" --body "Autofix workflow已接管：自动review+等待checks通过后自动merge。"
+          gh pr review "$PR" --repo "$REPO" --approve || true
           gh pr merge "$PR" --repo "$REPO" --auto --squash --delete-branch
           echo "Auto-merge enabled for PR #$PR"
 

--- a/.github/workflows/support-release-rollover.yml
+++ b/.github/workflows/support-release-rollover.yml
@@ -3,7 +3,7 @@ name: support-release-rollover
 "on":
   workflow_dispatch: {}
   workflow_run:
-    workflows: ["overlay-ci"]
+    workflows: ["overlay-ci", "auto-compat"]
     types: [completed]
 
 permissions:
@@ -16,8 +16,11 @@ jobs:
       (
         github.event_name == 'workflow_run' &&
         github.event.workflow_run.conclusion == 'success' &&
-        github.event.workflow_run.event == 'push' &&
-        github.event.workflow_run.head_branch == 'main'
+        github.event.workflow_run.head_branch == 'main' &&
+        (
+          github.event.workflow_run.name == 'auto-compat' ||
+          github.event.workflow_run.event == 'push'
+        )
       )
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
按最新规则重构 auto-compat：\n\n- 移除临时 skip 逻辑，发现新版本后走 hard path（任一步失败即失败）\n- 新增失败遗留状态文件 .github/auto-compat-state.json，并在 auto-compat 开始时判定\n- 失败（本次或遗留）触发 autofix-on-failure workflow_dispatch\n- autofix 支持 workflow_dispatch 输入上下文，自动 issue/PR review/auto-merge 协同\n- 成功路径增加 CHANGELOG 更新，并清理 failure residue\n- release rollover 支持由 auto-compat 成功直接触发\n\n请重点看 workflows 语义是否严格符合 1/2/3 规则。