### PR TITLE
ci: 修复 trigger-autofix 在失败后被默认 success() 跳过

### DIFF
--- a/.github/workflows/auto-compat.yml
+++ b/.github/workflows/auto-compat.yml
@@ -305,7 +305,7 @@ jobs:
           echo "residue issue #$issue"
 
   trigger-autofix:
-    if: github.event_name != 'pull_request' && (needs.discover.outputs.has_failure_residue == 'true' || needs.mark-failure-residue.result == 'success')
+    if: always() && github.event_name != 'pull_request' && (needs.discover.outputs.has_failure_residue == 'true' || needs.mark-failure-residue.result == 'success')
     needs: [discover, mark-failure-residue]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
给 trigger-autofix job 增加 always()，确保在 validate-and-pr 失败后仍可执行 autofix 触发。