### PR TITLE
fix(ci): remove copilot dispatch path from autofix-on-failure

### DIFF
--- a/.github/workflows/autofix-on-failure.yml
+++ b/.github/workflows/autofix-on-failure.yml
@@ -34,8 +34,8 @@ permissions:
   pull-requests: write
 
 jobs:
-  dispatch-copilot-fix:
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'failure'
+  dispatch-autofix:
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'failure')
     runs-on: ubuntu-latest
     steps:
       - name: Gather failed run context
@@ -137,13 +137,11 @@ jobs:
               '- Failed jobs: `${{ steps.ctx.outputs.failed_jobs }}`' \
               '- Run: ${{ steps.ctx.outputs.run_url }}' \
               '' \
-              'Task for GitHub Copilot coding agent:' \
+              'Task for repository autofix workflow:' \
               '1. Investigate the failed job(s) from the run URL above.' \
               '2. Propose and implement the minimal fix in this repository.' \
               '3. Open a PR with clear root-cause summary and test evidence.' \
-              '4. If needed, re-run affected workflow checks.' \
-              '' \
-              '@copilot please fix this CI failure automatically.'
+              '4. If needed, re-run affected workflow checks.'
 
             ISSUE_URL=$(gh issue create \
               --repo "$REPO" \
@@ -155,17 +153,8 @@ jobs:
 
           echo "issue_url=$ISSUE_URL" >> "$GITHUB_OUTPUT"
 
-      - name: Best-effort assign to Copilot
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          ISSUE_NUMBER=$(basename "${{ steps.issue.outputs.issue_url }}")
-          gh issue edit "$ISSUE_NUMBER" --repo "${{ steps.ctx.outputs.repo }}" --add-assignee copilot
-
   autoclose-resolved-autofix-issue:
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Close matching open autofix issue if resolution observed

--- a/.github/workflows/autofix-pr-automerge.yml
+++ b/.github/workflows/autofix-pr-automerge.yml
@@ -36,7 +36,7 @@ jobs:
           if echo "$LABELS" | grep -qx 'autofix'; then
             SHOULD="1"
           fi
-          if [[ "$HEAD" == autofix/* || "$HEAD" == copilot/* ]]; then
+          if [[ "$HEAD" == autofix/* ]]; then
             SHOULD="1"
           fi
 


### PR DESCRIPTION
## Summary
- rename job `dispatch-copilot-fix` to `dispatch-autofix`
- remove copilot-specific issue text/assignee from `autofix-on-failure`
- harden job conditions by scoping `workflow_run` checks to `workflow_run` events
- remove `copilot/*` branch dependency from autofix PR automerge

## Validation
- dispatch `autofix-on-failure` manually and verify jobs no longer include Copilot-specific behavior