### PR TITLE
fix: repair autofix-issue chain and enforce issue closure

### DIFF
--- a/.github/workflows/autofix-issue.yml
+++ b/.github/workflows/autofix-issue.yml
@@ -24,8 +24,9 @@ jobs:
               owner, repo, state: 'open', per_page: 100
             });
             const hit = issues.find(i => !i.pull_request && (
-              (i.labels || []).some(l => (l.name || '') === 'autofix_issue') ||
-              (i.title || '').startsWith('[autofix_issue]')
+              (i.labels || []).some(l => ['autofix_issue', 'autofix'].includes((l.name || '').toLowerCase())) ||
+              (i.title || '').startsWith('[autofix_issue]') ||
+              (i.title || '').startsWith('[autofix]')
             ));
             if (!hit) {
               core.setOutput('issue', '');

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -29,7 +29,7 @@ jobs:
   fix-and-pr:
     runs-on: ubuntu-latest
     outputs:
-      pr_number: ${{ steps.cpr.outputs.pull-request-number }}
+      pr_number: ${{ steps.prmeta.outputs.pr_number }}
       pr_operation: ${{ steps.cpr.outputs.pull-request-operation }}
     steps:
       - uses: actions/checkout@v4
@@ -68,6 +68,7 @@ jobs:
           labels: |
             autofix
       - name: Ensure PR exists
+        id: ensure_pr
         if: steps.cpr.outputs.pull-request-number == ''
         run: |
           echo "No PR created (no changes). Creating empty commit for auditability."
@@ -76,10 +77,26 @@ jobs:
           git checkout -b autofix/${{ github.run_id }}-empty
           git commit --allow-empty -m "fix(autofix): empty fix marker"
           git push -u origin HEAD
-          gh pr create --repo "${{ github.repository }}" --base main --head "autofix/${{ github.run_id }}-empty" \
-            --title "fix(autofix): empty fix marker" --body "Auto-generated empty fix PR"
+          pr_url=$(gh pr create --repo "${{ github.repository }}" --base main --head "autofix/${{ github.run_id }}-empty" \
+            --title "fix(autofix): empty fix marker" --body "Auto-generated empty fix PR")
+          pr_number=$(gh pr view "$pr_url" --repo "${{ github.repository }}" --json number --jq '.number')
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ github.token }}
+
+      - name: Resolve PR metadata
+        id: prmeta
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ -n "${{ steps.cpr.outputs.pull-request-number }}" ]; then
+            echo "pr_number=${{ steps.cpr.outputs.pull-request-number }}" >> "$GITHUB_OUTPUT"
+          elif [ -n "${{ steps.ensure_pr.outputs.pr_number }}" ]; then
+            echo "pr_number=${{ steps.ensure_pr.outputs.pr_number }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "Unable to determine PR number" >&2
+            exit 1
+          fi
 
   retrigger-auto-compat:
     needs: fix-and-pr
@@ -101,12 +118,20 @@ jobs:
           done
           merged=$(gh pr view "$PR" --repo "${{ github.repository }}" --json mergedAt --jq '.mergedAt != null')
           [ "$merged" = "true" ] || { echo "PR not merged in time"; exit 1; }
-      - name: Close mapped autofix issue
+      - name: Close mapped autofix issue (required)
         if: inputs.issue_number != ''
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh issue close "${{ inputs.issue_number }}" --repo "${{ github.repository }}" --comment "Auto-fixed via PR #${{ needs.fix-and-pr.outputs.pr_number }} and merged."
+
+      - name: Verify issue is closed (required gate)
+        if: inputs.issue_number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          state=$(gh issue view "${{ inputs.issue_number }}" --repo "${{ github.repository }}" --json state --jq '.state')
+          [ "$state" = "CLOSED" ] || { echo "Mapped issue #${{ inputs.issue_number }} is not closed"; exit 1; }
       - name: Re-trigger force auto-compat full run
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
- Fixed issue picker to match both `autofix_issue` and existing `autofix` labels/title prefix.
- Ensured `autofix.yml` always resolves PR number, including the empty-fix fallback path.
- Made issue closure a required gate with explicit post-close verification.
