### PR TITLE
fix: rebase personal patches for OpenClaw 2026.5.18

### DIFF
--- a/dist-overlay.tar.gz.sha256
+++ b/dist-overlay.tar.gz.sha256
@@ -1,1 +1,1 @@
-007801ab4ed80fba3051eb20a760947983c93066236c94d03ce4960aedcf3c1a  /tmp/openclaw-overlay-20260506-133058/gate-work/dist-overlay.tar.gz
+b02f5bb8761effa8abf718e4fe24548165eccb516975bce538c562dc9b8ebb39  /tmp/tmp.HBUlUCI0tb/dist-overlay.tar.gz

--- a/patches/3.9/0005-feat-slash-commands-bypass-session-queue-fast-path-c.patch
+++ b/patches/3.9/0005-feat-slash-commands-bypass-session-queue-fast-path-c.patch
@@ -1,79 +1,59 @@
-From 31c99124edc46d6da3982362f87cb81eed74dc5d Mon Sep 17 00:00:00 2001
+From ed7f721be2ec5b2aac3036b7058d2848449c58e4 Mon Sep 17 00:00:00 2001
 From: dda <dddabtc@users.noreply.github.com>
-Date: Tue, 14 Apr 2026 20:34:32 +0000
-Subject: [PATCH] feat: slash commands bypass session queue (fast-path control)
+Date: Wed, 20 May 2026 08:46:05 -0300
+Subject: [PATCH 05/10] feat: slash commands bypass session queue (fast-path
+ control)
 
 ---
- extensions/telegram/src/sequential-key.ts | 36 +++++++++++++++--------
- 1 file changed, 23 insertions(+), 13 deletions(-)
+ extensions/telegram/src/sequential-key.ts | 21 ++++++++++++++++++++-
+ 1 file changed, 20 insertions(+), 1 deletion(-)
 
 diff --git a/extensions/telegram/src/sequential-key.ts b/extensions/telegram/src/sequential-key.ts
-index 898d0d29f8..01dd8c5e51 100644
+index 6f5e1495c2..d4afb417ba 100644
 --- a/extensions/telegram/src/sequential-key.ts
 +++ b/extensions/telegram/src/sequential-key.ts
-@@ -1,5 +1,6 @@
- import type { Message, UserFromGetMe } from "@grammyjs/types";
- import { parseExecApprovalCommandText } from "openclaw/plugin-sdk/approval-reply-runtime";
+@@ -5,6 +5,7 @@ import {
+   maybeResolveTextAlias,
+   normalizeCommandBody,
+ } from "openclaw/plugin-sdk/command-auth-native";
 +import { isControlCommandMessage } from "openclaw/plugin-sdk/command-detection";
  import {
-   listChatCommands,
-   maybeResolveTextAlias,
-@@ -28,17 +29,15 @@ type TelegramSequentialKeyContext = {
-   };
- };
+   isAbortRequestText,
+   isBtwRequestText,
+@@ -21,6 +22,8 @@ const TELEGRAM_READ_ONLY_STATUS_COMMAND_KEYS = new Set([
+   "whoami",
+ ]);
  
--function resolveStatusCommandControlLane(params: {
--  rawText?: string;
--  botUsername?: string;
--}): boolean {
--  // Only read-only status commands should bypass the per-topic lane. Commands
--  // like /export-session stay on the normal lane because they materialize
--  // session state to disk and should not interleave with an active turn.
--  const normalizedBody = normalizeCommandBody(
--    params.rawText?.trim() ?? "",
--    params.botUsername ? { botUsername: params.botUsername } : undefined,
--  );
-+function resolveCommandControlLane(params: { rawText?: string; botUsername?: string }): boolean {
-+  // PERSONAL BUILD: chat control commands should bypass the per-topic lane so
-+  // users can inspect or adjust session behavior while a long turn is running.
-+  // Keep materializing/export and tool-execution commands on the normal lane.
++const TELEGRAM_PERSONAL_CONTROL_LANE_KEYS = new Set(["model", "reasoning", "session"]);
++
+ type TelegramSequentialKeyContext = {
+   chat?: { id?: number };
+   me?: UserFromGetMe;
+@@ -91,7 +94,23 @@ export function isTelegramControlLaneText(params: {
+   if (isTelegramTargetedStopCommand(params.rawText, params.botUsername)) {
+     return true;
+   }
+-  return isTelegramReadOnlyControlLaneText(params);
++  if (isTelegramReadOnlyControlLaneText(params)) {
++    return true;
++  }
 +  const normalizeOptions = params.botUsername ? { botUsername: params.botUsername } : undefined;
-+  if (!isControlCommandMessage(params.rawText?.trim() ?? "", undefined, normalizeOptions)) {
++  const trimmed = params.rawText?.trim() ?? "";
++  if (!isControlCommandMessage(trimmed, undefined, normalizeOptions)) {
 +    return false;
 +  }
-+  const normalizedBody = normalizeCommandBody(params.rawText?.trim() ?? "", normalizeOptions);
-   const alias = maybeResolveTextAlias(normalizedBody);
-   if (!alias) {
-     return false;
-@@ -46,7 +45,18 @@ function resolveStatusCommandControlLane(params: {
-   const command = listChatCommands().find((entry) =>
-     entry.textAliases.some((candidate) => candidate.trim().toLowerCase() === alias),
-   );
--  return command?.category === "status" && command.key !== "export-session";
-+  if (!command) {
++  const normalizedBody = normalizeCommandBody(trimmed, normalizeOptions);
++  const alias = maybeResolveTextAlias(normalizedBody);
++  if (!alias) {
 +    return false;
 +  }
-+  return ![
-+    "approve",
-+    "allowlist",
-+    "btw",
-+    "export-session",
-+    "skill",
-+    "subagents",
-+    "tts",
-+  ].includes(command.key);
++  const command = listChatCommands().find((entry) =>
++    entry.textAliases.some((candidate) => candidate.trim().toLowerCase() === alias),
++  );
++  return !!command && TELEGRAM_PERSONAL_CONTROL_LANE_KEYS.has(command.key);
  }
  
  export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): string {
-@@ -73,7 +83,7 @@ export function getTelegramSequentialKey(ctx: TelegramSequentialKeyContext): str
-     }
-     return "telegram:control";
-   }
--  if (resolveStatusCommandControlLane({ rawText, botUsername })) {
-+  if (resolveCommandControlLane({ rawText, botUsername })) {
-     if (typeof chatId === "number") {
-       return `telegram:${chatId}:control`;
-     }
 -- 
-2.34.1
+2.25.1
 

--- a/patches/3.9/0006-fix-reply-make-transient-retry-delay-abortable.patch
+++ b/patches/3.9/0006-fix-reply-make-transient-retry-delay-abortable.patch
@@ -1,4 +1,4 @@
-From 25c2956fc4d214e4615ed867f90417bba4505c80 Mon Sep 17 00:00:00 2001
+From 9eec9a02c61a1851f77d5454f17a16f7d4aaeb9a Mon Sep 17 00:00:00 2001
 From: dda <dddabtc@users.noreply.github.com>
 Date: Sun, 29 Mar 2026 04:52:48 -0300
 Subject: [PATCH 06/10] fix(reply): make transient retry delay abortable
@@ -8,17 +8,16 @@ Subject: [PATCH 06/10] fix(reply): make transient retry delay abortable
  1 file changed, 9 insertions(+), 4 deletions(-)
 
 diff --git a/src/auto-reply/reply/agent-runner-execution.ts b/src/auto-reply/reply/agent-runner-execution.ts
-index 18fc362..571241c 100644
+index 8d55a9cb04..500d05d760 100644
 --- a/src/auto-reply/reply/agent-runner-execution.ts
 +++ b/src/auto-reply/reply/agent-runner-execution.ts
-@@ -1,5 +1,6 @@
+@@ -1,4 +1,5 @@
  import crypto from "node:crypto";
- import fs from "node:fs";
 +import { setTimeout as delay } from "node:timers/promises";
  import {
    hasOutboundReplyContent,
    resolveSendableOutboundReplyParts,
-@@ -1353,10 +1354,14 @@ export async function runAgentTurnWithFallback(params: {
+@@ -2284,10 +2285,14 @@ export async function runAgentTurnWithFallback(params: {
          defaultRuntime.error(
            `Transient HTTP provider error before reply (${message}). Retrying once in ${TRANSIENT_HTTP_RETRY_DELAY_MS}ms.`,
          );
@@ -38,5 +37,5 @@ index 18fc362..571241c 100644
  
        defaultRuntime.error(`Embedded agent failed before reply: ${message}`);
 -- 
-2.34.1
+2.25.1
 

--- a/patches/3.9/0007-test-telegram-add-control-fast-path-regression-cover.patch
+++ b/patches/3.9/0007-test-telegram-add-control-fast-path-regression-cover.patch
@@ -1,17 +1,18 @@
-From 9582c0d912b94892e615b9ef46896090142c2389 Mon Sep 17 00:00:00 2001
+From 1f0a5cf6a27959109fca98120e050d4d4f6c612a Mon Sep 17 00:00:00 2001
 From: dda <dddabtc@users.noreply.github.com>
 Date: Tue, 14 Apr 2026 20:34:32 +0000
-Subject: [PATCH] test(telegram): add control fast-path regression coverage
+Subject: [PATCH 07/10] test(telegram): add control fast-path regression
+ coverage
 
 ---
  extensions/telegram/src/sequential-key.test.ts | 16 ++++++++++++++++
  1 file changed, 16 insertions(+)
 
 diff --git a/extensions/telegram/src/sequential-key.test.ts b/extensions/telegram/src/sequential-key.test.ts
-index b24f59d6c..12d3f26bb 100644
+index b09efa095e..490ab64199 100644
 --- a/extensions/telegram/src/sequential-key.test.ts
 +++ b/extensions/telegram/src/sequential-key.test.ts
-@@ -87,6 +87,22 @@ describe("getTelegramSequentialKey", () => {
+@@ -141,6 +141,22 @@ describe("getTelegramSequentialKey", () => {
        { message: mockMessage({ chat: mockChat({ id: 123 }), text: "/whoami" }) },
        "telegram:123:control",
      ],
@@ -32,8 +33,8 @@ index b24f59d6c..12d3f26bb 100644
 +      "telegram:123",
 +    ],
      [
-       { message: mockMessage({ chat: mockChat({ id: 123 }), text: "/export-session" }) },
+       { message: mockMessage({ chat: mockChat({ id: 123 }), text: "/diagnostics" }) },
        "telegram:123",
 -- 
-2.34.1
+2.25.1
 


### PR DESCRIPTION
## Summary
- Rebases `patches/3.9` over OpenClaw `2026.5.18` / `50a2481652b6a62d573ece3cead60400dc77020d`.
- Adapts Telegram control-lane fast path to upstream's new `/stop` and read-only status helpers without dropping personal control commands.
- Rebases abortable transient retry patch over upstream import changes.
- Refreshes the dist overlay artifact/checksum from the release gate.

## Root cause
Upstream 2026.5.18 changed `extensions/telegram/src/sequential-key.ts` in the same helper/import area touched by overlay patch 0005, so `git am` failed at that patch. After rebasing 0005, patch 0006 also needed import-context rebasing because the old `fs` import context was gone.

## Test plan
- `git am patches/3.9/*.patch` against fresh OpenClaw `50a2481652b6a62d573ece3cead60400dc77020d`
- `node scripts/run-vitest.mjs extensions/telegram/src/sequential-key.test.ts --run`
- `node scripts/run-vitest.mjs src/agents/bash-tools.exec.main-session-defaults.test.ts --run`
- `scripts/ci-release-gate.sh --version 2026.5.18 --commit 50a2481652b6a62d573ece3cead60400dc77020d --patch-dir patches/3.9`
