### PR TITLE
fix: refresh existing overlay releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
           node-version: '22'
       - name: Enable corepack
         run: corepack enable
+      - name: Validate release workflow refresh behavior
+        run: python3 tests/test_release_workflow.py
       - name: Validate compatibility matrix
         run: python3 scripts/validate-compatibility.py compatibility.json
       - name: Resolve latest supported target

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,22 +230,26 @@ jobs:
             --patch-dir "${{ steps.compat.outputs.patch_set_dir }}" \
             --out-prefix dist-overlay
 
-      - name: Create tag and release
+      - name: Create or refresh tag and release
         env:
           GH_TOKEN: ${{ secrets.OC_GH_TOKEN }}
           RELEASE_TAG: ${{ steps.normalize.outputs.release_tag }}
         run: |
-          git fetch --tags
-          if ! git rev-parse "${RELEASE_TAG}" >/dev/null 2>&1; then
-            git tag "${RELEASE_TAG}"
-            git push origin "${RELEASE_TAG}"
-          fi
+          set -euo pipefail
+          git fetch --tags --force
+          git tag -f "${RELEASE_TAG}" HEAD
+          git push --force origin "${RELEASE_TAG}"
           cat > /tmp/release-notes.md <<EOF
           Auto-compat release for upstream v${{ steps.normalize.outputs.upstream_version }}.
 
           Source: ${{ steps.normalize.outputs.source_run_url }}
+          Commit: $(git rev-parse HEAD)
           EOF
-          gh release view "${RELEASE_TAG}" >/dev/null 2>&1 || gh release create "${RELEASE_TAG}" --title "${RELEASE_TAG}" --notes-file /tmp/release-notes.md
+          if gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
+            gh release edit "${RELEASE_TAG}" --title "${RELEASE_TAG}" --notes-file /tmp/release-notes.md
+          else
+            gh release create "${RELEASE_TAG}" --title "${RELEASE_TAG}" --notes-file /tmp/release-notes.md
+          fi
 
       - name: Upload release assets
         env:

--- a/tests/test_release_workflow.py
+++ b/tests/test_release_workflow.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Regression tests for release workflow tag/release refresh behavior."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+
+
+def test_existing_overlay_release_tag_is_moved_to_current_head() -> None:
+    workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'git tag -f "${RELEASE_TAG}" HEAD' in workflow
+    assert 'git push --force origin "${RELEASE_TAG}"' in workflow
+
+
+def test_existing_overlay_release_notes_are_refreshed() -> None:
+    workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'gh release edit "${RELEASE_TAG}"' in workflow
+    assert '--notes-file /tmp/release-notes.md' in workflow
+
+
+def _run_without_pytest() -> None:
+    test_existing_overlay_release_tag_is_moved_to_current_head()
+    test_existing_overlay_release_notes_are_refreshed()
+
+
+if __name__ == "__main__":
+    _run_without_pytest()
+    print("release workflow regression tests passed")


### PR DESCRIPTION
## Summary
- Force-refresh existing overlay release tags to the current release workflow checkout
- Edit existing release notes instead of leaving stale releases untouched
- Add regression coverage in CI for release refresh behavior

## Test Plan
- python3 tests/test_release_workflow.py
- python3 -m pytest tests/test_release_workflow.py -q
- python3 scripts/validate-compatibility.py compatibility.json
- scripts/ci-release-gate.sh --version 2026.5.18 --commit 50a2481652b6a62d573ece3cead60400dc77020d --patch-dir patches/3.9 (running locally; CI also runs release gate)